### PR TITLE
Clarify the documentation source

### DIFF
--- a/docs/environment/conda.md
+++ b/docs/environment/conda.md
@@ -186,7 +186,7 @@ that opens up an interactive dialogue with details about the operations performe
 
 _Sources_
 
-- [Oficial documentation](https://docs.conda.io/projects/conda/en/latest/commands/clean.html)
+- [Oficial Conda `clean` documentation](https://docs.conda.io/projects/conda/en/latest/commands/clean.html)
 - [Understanding Conda `clean`](https://stackoverflow.com/questions/51960539/where-does-conda-clean-remove-packages-from)
 
 ## Combining Conda with other package and environment management tools


### PR DESCRIPTION
Minor clarification describing that the source of the documentation is Conda. Users have been already informed that Micromamba supports the same commands as Conda unless stated otherwise.