### PR TITLE
Update srun api

### DIFF
--- a/docs/development/performance-debugging-tools/advisor.md
+++ b/docs/development/performance-debugging-tools/advisor.md
@@ -70,10 +70,8 @@ module load toolchain/intel/2019a
 module load perf/Advisor/2019_update4
 module load vis/GTK+/3.24.8-GCCcore-8.2.0
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 export OMP_NUM_THREADS=16
 advixe-cl -collect survey -project-dir my_result -- ./a.out
-
 ```
 
 

--- a/docs/development/performance-debugging-tools/aps.md
+++ b/docs/development/performance-debugging-tools/aps.md
@@ -91,7 +91,6 @@ module load swenv/default-env/v1.2-20191021-production
 module load tools/VTune/2019_update4
 module load toolchain/intel/2019a
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 export OMP_NUM_THREADS=16
 aps --collection-mode=all -r report_output ./a.out
 ```
@@ -116,7 +115,6 @@ module load swenv/default-env/v1.2-20191021-production
 module load tools/VTune/2019_update4
 module load toolchain/intel/2019a
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 # To collect all the results
 export MPS_STAT_LEVEL=${SLURM_CPUS_PER_TASK:-1}
 # An option for the OpenMP+MPI application

--- a/docs/development/performance-debugging-tools/arm-forge.md
+++ b/docs/development/performance-debugging-tools/arm-forge.md
@@ -54,7 +54,6 @@ module load toolchain/intel/2019a
 module load tools/ArmForge/19.1
 module load tools/ArmReports/19.1
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
 
 # for debugging

--- a/docs/development/performance-debugging-tools/inspector.md
+++ b/docs/development/performance-debugging-tools/inspector.md
@@ -92,7 +92,6 @@ module load toolchain/intel/2019a
 module load tools/Inspector/2019_update4
 module load vis/GTK+/3.24.8-GCCcore-8.2.0
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 inspxe-cl -collect mi1 -result-dir mi1 -- ./a.out`
 ```
 To see the result:

--- a/docs/development/performance-debugging-tools/itac.md
+++ b/docs/development/performance-debugging-tools/itac.md
@@ -53,7 +53,6 @@ module load toolchain/intel/2019a
 module load tools/itac/2019.4.036
 module load vis/GTK+/3.24.8-GCCcore-8.2.0
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 $ export OMP_NUM_THREADS=16
 $ -trace-collective ./a.out
 ```

--- a/docs/development/performance-debugging-tools/scalasca.md
+++ b/docs/development/performance-debugging-tools/scalasca.md
@@ -52,7 +52,6 @@ module load toolchain/foss/2018a
 module load perf/Scalasca/2.3.1-foss-2018a
 module load perf/Score-P/3.1-foss-2018a
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 export OMP_NUM_THREADS=16
 
 # analyze

--- a/docs/development/performance-debugging-tools/vtune.md
+++ b/docs/development/performance-debugging-tools/vtune.md
@@ -48,7 +48,6 @@ module load toolchain/intel/2019a
 module load tools/VTune/2019_update4
 module load vis/GTK+/3.24.8-GCCcore-8.2.0
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 export OMP_NUM_THREADS=16
 amplxe-cl -collect hotspots-r my_result ./a.out
 ```

--- a/docs/environment/conda.md
+++ b/docs/environment/conda.md
@@ -148,7 +148,6 @@ echo "Numb. of cores: ${SLURM_CPUS_PER_TASK}"
 
 micromamba activate R-project
 
-export SRUN_CPUS_PER_TASK="${SLURM_CPUS_PER_TASK}"
 export OMP_NUM_THREADS=1
 srun Rscript --no-save --no-restore script.R
 

--- a/docs/jobs/gpu.md
+++ b/docs/jobs/gpu.md
@@ -28,7 +28,6 @@ print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
 module purge || print_error_and_exit "No 'module' command"
 module load numlib/cuDNN   # Example with cuDNN
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK # Propagate Slurm 'cpus-per-task' to srun
 [...]
 ```
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -59,7 +59,6 @@ The following script is an example how to proceed:
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
     
     # Python 3.X by default (also on system)
     module load lang/Python

--- a/docs/slurm/index.md
+++ b/docs/slurm/index.md
@@ -102,8 +102,8 @@ Within a job, you aim at running a certain number of **tasks**, and Slurm allow 
 
 The total number of tasks defined in a given job is stored in the `$SLURM_NTASKS` environment variable.
 
-!!! note "--cpus-per-task in `srun` in Slurm 23.11 and later"
-    In the latest versions of Slurm `srun` inherits the --cpus-per-task value requested by salloc or sbatch by reading the value of `SLURM_CPUS_PER_TASK`.
+!!! note "The --cpus-per-task option of srun in Slurm 23.11 and later"
+    In the latest versions of Slurm `srun` inherits the `--cpus-per-task` value requested by `salloc` or `sbatch` by reading the value of `SLURM_CPUS_PER_TASK`, as for any other option. _This behavior may differ from some older versions where special handling was required to propagate the `--cpus-per-task` option to `srun`._
 
 In case you would like to launch multiple programs in a single allocation/batch script, divide the resources accordingly by requesting resources with `srun` when launching the process, for instance:
 ```bash

--- a/docs/slurm/index.md
+++ b/docs/slurm/index.md
@@ -102,12 +102,12 @@ Within a job, you aim at running a certain number of **tasks**, and Slurm allow 
 
 The total number of tasks defined in a given job is stored in the `$SLURM_NTASKS` environment variable.
 
-!!! note "--cpus-per-task in srun since Slurm 22.05"
-    Beginning with Slurm 22.05, srun will not inherit the --cpus-per-task value requested by salloc or sbatch. It must be requested again with the call to srun or set with the SRUN_CPUS_PER_TASK environment variable if desired for the task(s).
+!!! note "--cpus-per-task in `srun` in Slurm 23.11 and later"
+    In the latest versions of Slurm `srun` inherits the --cpus-per-task value requested by salloc or sbatch by reading the value of `SLURM_CPUS_PER_TASK`.
 
-This is very convenient to abstract from the job context to run MPI tasks/processes in parallel using for instance:
+In case you would like to launch multiple programs in a single allocation/batch script, divide the resources accordingly by requesting resources with `srun` when launching the process, for instance:
 ```bash
-srun -c ${SLURM_CPUS_PER_TASK} -n ${SLURM_NTASKS} [...]
+srun --cpus-per-task <some of the SLURM_CPUS_PER_TASK> --ntasks <some of the SLURM_NTASKS> [...] <program>
 ```
 
 We encourage you to **always** explicitly specify upon resource allocation the number of tasks you want _per_ node/socket (`--ntasks-per-node <n> --ntasks-per-socket <s>`), to easily scale on multiple nodes with `-N <N>`. Adapt the number of threads and the settings to match the physical NUMA characteristics of the nodes
@@ -344,5 +344,5 @@ submitted.
 | `-N <N>`                  | `SLURM_JOB_NUM_NODES` or<br/> `SLURM_NNODES`   |                                          |
 | `--ntasks-per-node=<n>`   | `SLURM_NTASKS_PER_NODE`                   |                                          |
 | `--ntasks-per-socket=<s>` | `SLURM_NTASKS_PER_SOCKET`                 |                                          |
-| `-c <c>`                  | `SLURM_CPUS_PER_TASK`                     | `OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}` and `SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}` |
+| `-c <c>`                  | `SLURM_CPUS_PER_TASK`                     | `OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}` |
 |                           | `SLURM_NTASKS`<br/> Total number of tasks | `srun -n $SLURM_NTASKS [...]`            |

--- a/docs/slurm/launchers.md
+++ b/docs/slurm/launchers.md
@@ -103,8 +103,6 @@ When setting your default `#SBATCH` directive, always keep in mind your expected
         module purge || print_error_and_exit "No 'module' command"
         # List modules required for execution of the task
         module load <...>
-        # Propagate Slurm "-c" option to srun
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         # [...]
         ```
 
@@ -121,7 +119,6 @@ When setting your default `#SBATCH` directive, always keep in mind your expected
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load <...>
         # [...]
         ```
@@ -139,7 +136,6 @@ When setting your default `#SBATCH` directive, always keep in mind your expected
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load <...>
         # [...]
         ```
@@ -193,7 +189,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         # C/C++: module load toolchain/intel # OR: module load toolchain/foss
         # Java:  module load lang/Java/1.8
         # Ruby/Perl/Rust...:  module load lang/{Ruby,Perl,Rust...}
@@ -216,7 +211,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         # Python 3.X by default (also on system)
         module load lang/Python
         # module load lang/SciPy-bundle
@@ -240,7 +234,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load lang/R
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
         OPTS=$*
@@ -262,7 +255,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load math/MATLAB
 
         matlab -nodisplay -nosplash < INPUTFILE.m > OUTPUTFILE.out
@@ -287,7 +279,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
 	print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
 	module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 	module load <...>
 	# [...]
 	```
@@ -305,7 +296,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
 	print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
 	module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 	module load <...>    # USE apps compiled against the {foss,intel}cuda toolchain !
     # Ex: 
     # module load numlib/cuDNN
@@ -339,7 +329,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
 
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
@@ -361,7 +350,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
 
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
@@ -391,7 +379,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/intel
         OPTS=$*
 
@@ -413,7 +400,6 @@ Luckily, we have prepared a [generic GNU Parallel launcher](https://github.com/U
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/intel
         OPTS=$*
 
@@ -442,7 +428,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
         module load mpi/OpenMPI
         OPTS=$*
@@ -464,7 +449,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
         module load mpi/OpenMPI
         OPTS=$*
@@ -489,7 +473,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/intel
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
         OPTS=$*
@@ -512,7 +495,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/intel
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
         OPTS=$*
@@ -537,7 +519,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
         module load mpi/OpenMPI
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
@@ -561,7 +542,6 @@ You may want to use [PMIx](https://pmix.github.io/standard) as MPI initiator -- 
 
         print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
         module purge || print_error_and_exit "No 'module' command"
-        export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
         module load toolchain/foss
         module load mpi/OpenMPI
         export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}

--- a/docs/software/build.md
+++ b/docs/software/build.md
@@ -173,8 +173,6 @@ From that point, the compiled software and associated module is available in you
 #SBATCH -c <thread>
 
 print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
-# Propagate Slurm "cpus-per-task" to srun
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 # Safeguard for NOT running this launcher on access/login nodes
 module purge || print_error_and_exit "No 'module' command"
 
@@ -211,8 +209,6 @@ From that point, the compiled software and associated module is available in the
 #SBATCH -c <thread>
 
 print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
-# Propagate Slurm "cpus-per-task" to srun
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 # Safeguard for NOT running this launcher on access/login nodes
 module purge || print_error_and_exit "No 'module' command"
 

--- a/docs/software/cae/abaqus.md
+++ b/docs/software/cae/abaqus.md
@@ -87,9 +87,6 @@ $ si --x11 -c 8               # Abaqus mp_mode=threads test
 # OR
 $ si --x11 --ntask-per-node 8 # abaqus mp_mode=mpi test
 
-# Propagate Slurm "cpus-per-task / -c" to srun
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Load the module ABAQUS and needed environment
 (node)$ module purge
 (node)$ module load cae/ABAQUS
@@ -161,7 +158,6 @@ abaqus job=<jobname> resume
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
     module load cae/ABAQUS
     # export LM_LICENSE_FILE=[...]
     unset SLURM_GTIDS
@@ -185,7 +181,6 @@ abaqus job=<jobname> resume
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
     module load cae/ABAQUS
     # export LM_LICENSE_FILE=[...]
     unset SLURM_GTIDS
@@ -211,7 +206,6 @@ abaqus job=<jobname> resume
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
-    export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
     module load cae/ABAQUS
     # export LM_LICENSE_FILE=[...]
     unset SLURM_GTIDS

--- a/docs/software/cae/ansys.md
+++ b/docs/software/cae/ansys.md
@@ -25,9 +25,6 @@ $ ssh -X iris-cluster
 # Reserve the node for interactive computation
 $ salloc -p interactive --time=00:30:00 --ntasks 1 -c 4 --x11 
 
-# Propagate Slurm "cpus-per-task / -c" to srun
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Load the required version of ANSYS and needed environment
 $ module purge
 $ module load toolchain/intel/2019a
@@ -70,7 +67,6 @@ module load tools/ANSYS/19.4
 # The Input file
 defFile=Benchmark.def
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 MYHOSTLIST=$(srun hostname | sort | uniq -c | awk '{print $2 "*" $1}' | paste -sd, -)
 echo $MYHOSTLIST
 cfx5solve -double -def $defFile -start-method "Platform MPI Distributed Parallel" -par-dist $MYHOSTLIST

--- a/docs/software/cae/fds.md
+++ b/docs/software/cae/fds.md
@@ -24,7 +24,6 @@ $ salloc -p interactive --time=00:30:00 --ntasks 1 -c 4 --x11
 $ module purge
 $ module load swenv/default-env/devel
 $ module load phys/FDS/6.7.3-intel-2019a
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 # Example in fds 
 $ fds example.fds
@@ -61,7 +60,6 @@ module purge
 module load swenv/default-env/devel
 module load phys/FDS/6.7.3-intel-2019a
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 srun fds example.fds
 ```
 

--- a/docs/software/cae/fenics.md
+++ b/docs/software/cae/fenics.md
@@ -19,8 +19,6 @@ $ ssh -X iris-cluster    # OR ssh -Y iris-cluster on Mac
 $ si --x11 --ntasks-per-node 1 -c 4
 # salloc -p interactive --qos debug -C batch --x11 --ntasks-per-node 1 -c 4
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Go to scratch directory 
 $ cds
 
@@ -63,8 +61,6 @@ $ ssh -X iris-cluster      # or ssh -Y iris-cluster on Mac
 $ si --ntasks-per-node 1 -c 4 --x11
 # salloc -p interactive --qos debug -C batch --x11 --ntasks-per-node 1 -c 4
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Activate anaconda  
 $ source /${SCRATCH}/Anaconda3/bin/activate
 
@@ -98,7 +94,6 @@ source ${SCRATCH}/Anaconda3/bin/activate
 conda activate fenicsproject
 
 # execute the poisson.py through python
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 srun python3 Poisson.py  
 ```
 

--- a/docs/software/cae/meshing-tools.md
+++ b/docs/software/cae/meshing-tools.md
@@ -38,7 +38,6 @@ $ module purge
 $ module load swenv/default-env/v1.2-20191021-production
 $ module load cae/gmsh/4.4.0-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 $ gmsh example.geo
 ```
 ## Salome
@@ -74,7 +73,6 @@ $ module purge
 $ module load swenv/default-env/v1.2-20191021-production
 $ module load cae/Salome/8.5.0-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 $ salome start
 ```
 

--- a/docs/software/cae/openfoam.md
+++ b/docs/software/cae/openfoam.md
@@ -29,7 +29,6 @@ $ module load swenv/default-env/v1.1-20180716-production
 $ module load cae/OpenFOAM/v1712-intel-2018a
 
 # Load the OpenFOAM environment
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 $ source $FOAM_BASH
 
 $ mkdir OpenFOAM
@@ -91,7 +90,6 @@ module load swenv/default-env/v1.1-20180716-production
 module load cae/OpenFOAM/v1712-intel-2018a
 
 # Load the OpenFOAM environment
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 source $FOAM_BASH
 
 srun interFoam -parallel

--- a/docs/software/computational-chemistry/electronics/ase.md
+++ b/docs/software/computational-chemistry/electronics/ase.md
@@ -33,8 +33,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/ASE/3.17.0-intel-2019a-Python-3.7.2
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ python3 example.py
 ```
 

--- a/docs/software/computational-chemistry/electronics/crystal.md
+++ b/docs/software/computational-chemistry/electronics/crystal.md
@@ -36,8 +36,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/CRYSTAL/17-intel-2019a-1.0.2
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ Pcrystal >& log.out
 ```
 

--- a/docs/software/computational-chemistry/electronics/meep.md
+++ b/docs/software/computational-chemistry/electronics/meep.md
@@ -29,8 +29,6 @@ $ module load swenv/default-env/devel # Eventually (only relevant on 2019a softw
 $ module load toolchain/intel/2019a
 $ module load phys/Meep/1.4.3-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ meep example.ctl > result_output
 ```
 

--- a/docs/software/computational-chemistry/electronics/quantum-espresso.md
+++ b/docs/software/computational-chemistry/electronics/quantum-espresso.md
@@ -41,8 +41,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/QuantumESPRESSO/6.4.1-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ pw.x -input example.in
 ```
 

--- a/docs/software/computational-chemistry/electronics/vasp.md
+++ b/docs/software/computational-chemistry/electronics/vasp.md
@@ -29,8 +29,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load phys/VASP/5.4.4-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ vasp_[std/gam/ncl]
 ```
 

--- a/docs/software/computational-chemistry/molecular-dynamics/cp2k.md
+++ b/docs/software/computational-chemistry/molecular-dynamics/cp2k.md
@@ -34,8 +34,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/CP2K/6.1-intel-2018a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
- 
 $ cp2k.popt -i example.inp 
 ```
 

--- a/docs/software/computational-chemistry/molecular-dynamics/gromacs.md
+++ b/docs/software/computational-chemistry/molecular-dynamics/gromacs.md
@@ -34,8 +34,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load bio/GROMACS/2019.2-intel-2019a
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ gmx_mpi mdrun <all your GMX job specification options in here>
 ```
 

--- a/docs/software/computational-chemistry/molecular-dynamics/namd.md
+++ b/docs/software/computational-chemistry/molecular-dynamics/namd.md
@@ -33,8 +33,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/NAMD/2.12-intel-2018a-mpi
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ namd2 +setcpuaffinity +p4 config_file > output_file
 ```
 

--- a/docs/software/computational-chemistry/molecular-dynamics/nwchem.md
+++ b/docs/software/computational-chemistry/molecular-dynamics/nwchem.md
@@ -29,8 +29,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load chem/NWChem/6.8.revision47-intel-2019a-Python-2.7.15
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ nwchem example
 ```
 

--- a/docs/software/maths/julia.md
+++ b/docs/software/maths/julia.md
@@ -24,8 +24,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load lang/Julia/1.3.0
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ julia
 ```
 
@@ -45,8 +43,6 @@ $ julia
 module purge
 module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 module load lang/Julia/1.3.0
-
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 julia {example}.jl
 ```

--- a/docs/software/maths/mathematica.md
+++ b/docs/software/maths/mathematica.md
@@ -30,8 +30,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load math/Mathematica/12.0.0
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ math
 ```
 
@@ -52,8 +50,6 @@ $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load math/Mathematica/12.0.0
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ srun -n ${SLURM_NTASKS} math -run < {mathematica-script-file}.m
 ```
 
@@ -72,8 +68,6 @@ $ srun -n ${SLURM_NTASKS} math -run < {mathematica-script-file}.m
 $ module purge
 $ module load swenv/default-env/devel # Eventually (only relevant on 2019a software environment) 
 $ module load math/Mathematica/12.0.0
-
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 $ srun -n ${SLURM_NTASKS} math -run < {mathematica-script-file}.m
 ```

--- a/docs/software/optim/index.md
+++ b/docs/software/optim/index.md
@@ -105,8 +105,6 @@ The below launcher is an example showing how to reserve ressources on multiple n
 #SBATCH --qos=normal
 module load math/CPLEX
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Some variables
 MPS_FILE=$1
 RES_FILE=$2
@@ -152,8 +150,6 @@ The script below allows you to start multi-threaded MIP optimization with Gurobi
 # Load Gurobi 
 module load math/Gurobi
 
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 # Some variable
 MPS_FILE=$1
 RES_FILE=$2
@@ -183,8 +179,6 @@ Using the script ```gurobi_mtt.slurm ```, you can launch a batch job with the ``
 mu
 # Load gurobi
 module load math/Gurobi
-
-export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 
 export MASTER_PORT=61000
 export SLAVE_PORT=61000

--- a/docs/software/visu/paraview.md
+++ b/docs/software/visu/paraview.md
@@ -44,8 +44,6 @@ $ module purge
 $ module load swenv/default-env/latest
 $ module load vis/ParaView/5.6.2-intel-2019a-mpi
 
-$ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-
 $ paraview &
 ```
 


### PR DESCRIPTION
Remove all mentions from the documentation and update all examples.

After the update to SLURM 23.11, the SRUN_CPUS_PER_TASK variable is deprecated. For more details, see the SchedMD release notes:

- Slurm 23.02 Release Notes: https://github.com/SchedMD/slurm/blob/slurm-23.02/RELEASE_NOTES
- Slurm 23.11 Release Notes: https://github.com/SchedMD/slurm/blob/slurm-23.11/RELEASE_NOTES