### PR TITLE
Refactor/jupyter

### DIFF
--- a/docs/connect/ssh.md
+++ b/docs/connect/ssh.md
@@ -485,7 +485,7 @@ This is useful if you run a server on one of the cluster nodes (let's say listen
 
 ```bash
 # Here targeting iris cluster
-(laptop)$ ssh iris-cluster -L 1111:iris-014:2222
+(laptop) $ ssh iris-cluster -L 1111:iris-014:2222
 ```
 
 #### Forwarding a remote port
@@ -494,6 +494,12 @@ You can forward a remote port back to a host protected by your firewall.
 
 ![SSH forward of a remote port](images/SshR.png)
 
+This is useful when you want the HPC node to access some local service. For instance is your local machine runs a service that is listening at some local port, say 2222, and you have some service in the HPC node that listens to some local port, say 1111, then the you'll run:
+
+```bash
+# Here targeting the iris cluster
+(local machine) $ ssh iris-cluster -R 1111:$(hostname -i):2222
+```
 
 #### Tunnelling for others
 

--- a/docs/connect/ssh.md
+++ b/docs/connect/ssh.md
@@ -61,7 +61,7 @@ Your key pairs will be located under `~/.ssh/` and follow the following format -
 ```bash
 $ ls -l ~/.ssh/id_*
 -rw------- username groupname ~/.ssh/id_rsa
--rw-r--r-- username groupname ~/.ssh/id_rsa.pub		# Public  RSA key
+-rw-r--r-- username groupname ~/.ssh/id_rsa.pub     # Public  RSA key
 -rw------- username groupname ~/.ssh/id_ed25519
 -rw-r--r-- username groupname ~/.ssh/id_ed25519.pub # Public ED25519 key
 ```

--- a/docs/connect/ssh.md
+++ b/docs/connect/ssh.md
@@ -508,7 +508,19 @@ By using the `-g` parameter, you allow connections from other hosts than localho
 
 ### SSH jumps
 
-Compute nodes are not directly accessible through the network. To login into a cluster node you will need to jump through a login node. The ssh agent is [not configured in the login nodes](#on-ulhpc-clusters) for security reasons. To configure a jump to a compute node, you will need to install a key in your ssh configuration. Create a key in your local machine,
+Compute nodes are not directly accessible from the outside network. To login into a cluster node you will need to jump through a login node. Remember, you need a job running in a node before you can ssh into it. Assume that you have some job running on `aion-0014` for instance. Then, connect to `aion-0014` with:
+
+```bash
+ssh -J ${USER}@access-aion.uni.lu:8022 ${USER}@aion-0014
+```
+
+The domain resolution in the login node will determine the IP of the `aion-0014`. You can always use the IP address if the node directly if you know it.
+
+#### Passwordless SSH jumps
+
+The ssh agent is [not configured in the login nodes](#on-ulhpc-clusters) for security reasons. As a result, compute nodes will request your password. To configure a passwordless jump to a compute node, you will need to install the same key in your ssh configuration of your local machine and the login node.
+
+To avoid exposing your keys at your personal machine, create and share a new key. Create a key in your local machine,
 ```bash
 ssh-keygen -a 127 -t ed25519 -f ~/.ssh/hpc_id_ed25519
 ```
@@ -520,12 +532,20 @@ where the command assumes that you have setup your [SSH configuration file](#ssh
 ```bash
 ssh-copy-id -i ~/.ssh/hpc_id_ed25519 aion-cluster
 ```
-Then you can connect to any compute node to which you have a job running with the command:
+Then you can connect without a password to any compute node at which you have a job running with the command:
 ```bash
 ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-aion.uni.lu:8022 ${USER}@<node address>
 ```
 
- Usually the node address can be the node IP of the node name. You can combine this command with other options, such as [port forwarding](#ssh-port-forwarding), for instance to access a web server running in a compute node.
+In the `<node address>` option you can use the node IP address or the node name.
+
+#### Port forwarding over SSH jumps
+
+You can combine the jump command with other options, such as [port forwarding](#ssh-port-forwarding), for instance to access from you local machine a web server running in a compute node. Assume for instance you have a server running in `iris-014` and listens at port `2222`, and that you would like to forward the port `2222` to the `2222` port of you local machine. The, call the port forwarding command with a jump though the login node:
+
+```bash
+ssh -J iris-cluster -L 1111:iris-014:2222 <cluster username>@iris-014
+```
 
 ## Extras Tools around SSH
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -52,7 +52,7 @@ You can [setup kernels with different environments on the same notebook](https:/
 ```shell
 source ~/environments/other_python_venv/bins/activate
 python -m pip install ipykernel
-python -m ipykernel install --prefix=~/environments/jupyter_env --name "Other Python env"
+python -m ipykernel install --prefix=~/environments/jupyter_env --name other_python_env --display-name "Other Python env"
 deactivate
 ```
 Then all kernels and their associated environment can be started from the same Jupyter instance in the `~/environments/jupyter_env` Python venv.
@@ -64,7 +64,7 @@ You can also use the flag `--user` instead of `--prefix` to install the kernel i
 If you would like to install a kernel in a Conda environment, install the `ipykernel` from the `conda-forge` channel. For instance,
 ```bash
 micromamba install --name conda_env conda-forge::ipykernel
-micromamba run --name conda_env python -m ipykernel install --prefix=~/environments/jupyter_env --name "Other Python env"
+micromamba run --name conda_env python -m ipykernel install --prefix=~/environments/jupyter_env --name other_python_env --display-name "Other Python env"
 ```
 will make your conda environment, `conda_env`, available in the kernel launched from the `~/environments/jupyter_env` Python venv.
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -151,7 +151,12 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     wait ${lab_pid}
     ```
 
-Once your job is running (see [Joining/monitoring running jobs](../jobs/submit.md#joiningmonitoring-running-jobs)), you can use `ssh` [forwarding](../connect/ssh.md#ssh-port-forwarding) and an [ssh jump](../connect/ssh.md#ssh-jumps) through the login node to connect to the notebook from your laptop. Open a terminal on your laptop and copy-paste the ssh command contained in the file `connection_instructions.log`, and then navigate to the webpage link provided.
+Once your job is running (see [Joining/monitoring running jobs](/jobs/submit.md#joiningmonitoring-running-jobs)), you can combine 
+
+- [`ssh` forwarding](/connect/ssh.md#ssh-port-forwarding), and
+- an [`ssh` jump](/connect/ssh.md#port-forwarding-over-ssh-jumps) through the login node,
+
+to connect to the notebook from your laptop. Open a terminal on your laptop and copy-paste the ssh command contained in the file `connection_instructions.log`, and then navigate to the webpage link provided.
 
 !!! example "Example content  of `connection_instructions.log`"
     ```shell
@@ -168,11 +173,11 @@ Once your job is running (see [Joining/monitoring running jobs](../jobs/submit.m
     http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
     ```
 
-As the instructions suggest, you should be able to access the node by calling
+As the instructions suggest, you access the jupyter lab server in the compute node by calling
 ```shell
 ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:172.21.12.29:8888 gkafanas@172.21.12.29
 ```
-a command that
+an SSH command that
 
 - opens a connection to your allocated cluster node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
 - exports the port to the jupyter server in the local machine (`-L 8888:172.21.12.29:888`).
@@ -185,7 +190,7 @@ http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
 The link provides the access token, so you should be able to login without a password.
 
 !!! warning
-    Do not forget to click on the `quit` button when finished to stop the jupyter server and release the resources. Note that in the last line of the submission script the job waits for your Jupyter service to finish. 
+    Do not forget to click on the `quit` button when finished to stop the Jupyter server and release the resources. Note that in the last line of the submission script the job waits for your Jupyter service to finish. 
 
 If you encounter any issues, have a look in the debug output in `Jupyter_<job id>.out`.
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -109,6 +109,8 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     echo "Then navigate to:" >> "${connection_instructions}"
 
     # Wait for the server to start
+    sleep 2s
+    # Wait and check that the landing page is available
     curl \
         --connect-timeout 10 \
         --retry 5 \

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -79,10 +79,11 @@ The following script is an example how to proceed:
     #SBATCH --job-name=Jupyter
     #SBATCH --nodes=1
     #SBATCH --ntasks-per-node=1
-    #SBATCH --cpus-per-task=2 # Note that ~1.7GB RAM is proivisioned per core
+    #SBATCH --cpus-per-task=2   # Note that ~1.7GB RAM is proivisioned per core
     #SBATCH --partition=batch
     #SBATCH --qos=normal
     #SBATCH --time=0-01:00:00
+    #SBATCH --output=%x_%j.out  # Print messages in 'Jupyter_<job id>.out'
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
@@ -93,11 +94,29 @@ The following script is an example how to proceed:
 
     jupyter lab --ip $(hostname -i) --no-browser &
     pid=$!
-    sleep 5s
-    jupyter lab list
-    jupyter --paths
-    jupyter kernelspec list
+
     echo "Enter this command on your laptop: ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-iris.uni.lu:8022 -L 8888:$(hostname -i):8888 ${USER}@$(hostname -i)" > notebook.log
+
+    sleep 5s
+
+    echo -e '\n===\n'
+
+    echo "AVAILABLE LABS"
+    echo ""
+    jupyter lab list
+
+    echo -e '\n===\n'
+
+    echo "CONFIGURATION PATHS"
+    echo ""
+    jupyter --paths
+
+    echo -e '\n===\n'
+
+    echo "KERNEL SPECIFICATIONS"
+    echo ""
+    jupyter kernelspec list
+
     wait $pid
     ```
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -78,10 +78,11 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     #SBATCH --job-name=Jupyter
     #SBATCH --nodes=1
     #SBATCH --ntasks-per-node=1
-    #SBATCH --cpus-per-task=2   # Note that ~1.7GB RAM is proivisioned per core
+    #SBATCH --cpus-per-task=2   # Change accordingly, note that ~1.7GB RAM is proivisioned per core
     #SBATCH --partition=batch
     #SBATCH --qos=normal
-    #SBATCH --output=%x_%j.out  # Print messages in 'Jupyter_<job id>.out'
+    #SBATCH --output=%x_%j.out  # Print messages to 'Jupyter_<job id>.out
+    #SBATCH --error=%x_%j.err   # Print debug messages to 'Jupyter_<job id>.err
     #SBATCH --time=0-01:00:00   # Change maximum allowable jupyter server uptime here
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
@@ -101,10 +102,10 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     echo "# Connection instructions" > "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "To access the jupyter notebook execute on your personal machine:" >> "${connection_instructions}"
-    echo "ssh -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L 8888:$(hostname -i):8888 ${USER}@$(hostname -i)" >> "${connection_instructions}"
+    echo "ssh -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:$(hostname -i):${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "To access the jupyter notebook if you have setup a key to connect to cluster nodes execute on your personal machine:" >> "${connection_instructions}"
-    echo "ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L 8888:$(hostname -i):8888 ${USER}@$(hostname -i)" >> "${connection_instructions}"
+    echo "ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:$(hostname -i):${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "Then navigate to:" >> "${connection_instructions}"
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -64,13 +64,14 @@ The following script is an example how to proceed:
 
 !!! example "Slurm Launcher script for Jupyter Notebook"
     ```slurm
-    #!/bin/bash -l
-    #SBATCH -J Jupyter
-    #SBATCH -N 1
+    #!/usr/bin/bash --login
+    #SBATCH --job-name=Jupyter
+    #SBATCH --nodes=1
     #SBATCH --ntasks-per-node=1
-    #SBATCH -c 2                # Cores assigned to each tasks
+    #SBATCH --cpus-per-task=2 # Note that ~1.7GB RAM is proivisioned per core
+    #SBATCH --partition=batch
+    #SBATCH --qos=normal
     #SBATCH --time=0-01:00:00
-    #SBATCH -p batch
 
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -105,7 +105,6 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     echo "" >> "${connection_instructions}"
     echo "To access the jupyter notebook if you have setup a key to connect to cluster nodes execute on your personal machine:" >> "${connection_instructions}"
     echo "ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L 8888:$(hostname -i):8888 ${USER}@$(hostname -i)" >> "${connection_instructions}"
-    echo "To access the jupyter notebook execute on your personal machine:" >> "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "Then navigate to:" >> "${connection_instructions}"
 
@@ -149,63 +148,114 @@ Jupyter notebooks must be started as [slurm jobs](../jobs/submit.md). The follow
     wait ${lab_pid}
     ```
 
-Once your job is running (see [Joining/monitoring running jobs](../jobs/submit.md#joiningmonitoring-running-jobs)), you can use `ssh` [forwarding](../connect/ssh.md#ssh-port-forwarding) and an [ssh jump](../connect/ssh.md#ssh-jumps) through the login node to connect to the notebook from your laptop. Open a terminal on your laptop and copy-paste the ssh command in the file `connection_instructions.log`, and then navigate to the webpage link provided.
+Once your job is running (see [Joining/monitoring running jobs](../jobs/submit.md#joiningmonitoring-running-jobs)), you can use `ssh` [forwarding](../connect/ssh.md#ssh-port-forwarding) and an [ssh jump](../connect/ssh.md#ssh-jumps) through the login node to connect to the notebook from your laptop. Open a terminal on your laptop and copy-paste the ssh command contained in the file `connection_instructions.log`, and then navigate to the webpage link provided.
 
-
-You should be now able to reach your notebook.
-
-Then open your browser and go to the url: `http://127.0.0.1:8888/`. Jupyter should ask you for a password (see screenshot below). This password can be set before running the jupyter notebook and his part of the initial configuration detailed at [Jupyter official documentation](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html).
-
-![](./images/jupyter_login.png)
-
-if by mistake, you forgot to setup this password, have a look in the slurm-****.out file in which the output of the command `jupyter notebook list` has been recorded.
-
-```shell
->$ cat slurm-3528839.out 
-[I 2024-07-15 16:14:22.538 ServerApp] jupyter_lsp | extension was successfully linked.
-[I 2024-07-15 16:14:22.545 ServerApp] jupyter_server_terminals | extension was successfully linked.
-[I 2024-07-15 16:14:22.552 ServerApp] jupyterlab | extension was successfully linked.
-[I 2024-07-15 16:14:22.843 ServerApp] notebook_shim | extension was successfully linked.
-[I 2024-07-15 16:14:22.865 ServerApp] notebook_shim | extension was successfully loaded.
-[I 2024-07-15 16:14:22.871 ServerApp] jupyter_lsp | extension was successfully loaded.
-[I 2024-07-15 16:14:22.872 ServerApp] jupyter_server_terminals | extension was successfully loaded.
-[I 2024-07-15 16:14:22.875 LabApp] JupyterLab extension loaded from /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/lib/python3.8/site-packages/jupyterlab
-[I 2024-07-15 16:14:22.875 LabApp] JupyterLab application directory is /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/share/jupyter/lab
-[I 2024-07-15 16:14:22.876 LabApp] Extension Manager is 'pypi'.
-[I 2024-07-15 16:14:22.889 ServerApp] jupyterlab | extension was successfully loaded.
-[I 2024-07-15 16:14:22.890 ServerApp] Serving notebooks from local directory: /mnt/aiongpfs/users/gkafanas/tmp
-[I 2024-07-15 16:14:22.890 ServerApp] Jupyter Server 2.14.2 is running at:
-[I 2024-07-15 16:14:22.890 ServerApp] http://172.17.6.2:8888/lab?token=a3bcac16d3923f7e8909ac3dfb7593affe6fdb547b5ebd88
-[I 2024-07-15 16:14:22.890 ServerApp]     http://127.0.0.1:8888/lab?token=a3bcac16d3923f7e8909ac3dfb7593affe6fdb547b5ebd88
-[I 2024-07-15 16:14:22.890 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
-[C 2024-07-15 16:14:22.897 ServerApp] 
+!!! example "Example content  of `connection_instructions.log`"
+    ```shell
+    > cat connection_instructions.log
+    # Connection instructions
     
-    To access the server, open this file in a browser:
-        file:///home/users/gkafanas/.local/share/jupyter/runtime/jpserver-126637-open.html
-    Or copy and paste one of these URLs:
-        http://172.17.6.2:8888/lab?token=a3bcac16d3923f7e8909ac3dfb7593affe6fdb547b5ebd88
-        http://127.0.0.1:8888/lab?token=a3bcac16d3923f7e8909ac3dfb7593affe6fdb547b5ebd88
-[I 2024-07-15 16:14:22.919 ServerApp] Skipped non-installed server(s): bash-language-server, dockerfile-language-server-nodejs, javascript-typescript-langserver, jedi-language-server, julia-language-server, pyright, python-language-server, python-lsp-server, r-languageserver, sql-language-server, texlab, typescript-language-server, unified-language-server, vscode-css-languageserver-bin, vscode-html-languageserver-bin, vscode-json-languageserver-bin, yaml-language-server
-Currently running servers:
-http://172.17.6.2:8888/?token=a3bcac16d3923f7e8909ac3dfb7593affe6fdb547b5ebd88 :: /mnt/aiongpfs/users/gkafanas/tmp
-config:
-    /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/etc/jupyter
-    /mnt/aiongpfs/users/gkafanas/.jupyter
-    /usr/local/etc/jupyter
-    /etc/jupyter
-data:
-    /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/share/jupyter
-    /home/users/gkafanas/.local/share/jupyter
-    /usr/local/share/jupyter
-    /usr/share/jupyter
-runtime:
-    /home/users/gkafanas/.local/share/jupyter/runtime
-Available kernels:
-  python3    /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/share/jupyter/kernels/python3
-  ir         /home/users/gkafanas/.local/share/jupyter/kernels/ir 
+    To access the jupyter notebook execute on your personal machine:
+    ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:172.21.12.29:8888 gkafanas@172.21.12.29
+    
+    To access the jupyter notebook if you have setup a key to connect to cluster nodes execute on your personal machine:
+    ssh -i ~/.ssh/hpc_id_ed25519 -J gkafanas@access-aion.uni.lu:8022 -L 8888:172.21.12.29:8888 gkafanas@172.21.12.29
+    
+    Then navigate to:
+    http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
+    ```
+
+As the instructions suggest, you should be able to access the node by calling
+```shell
+ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:172.21.12.29:8888 gkafanas@172.21.12.29
+```
+a command that
+
+- opens a connection to your allocated cluster node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
+- exports the port to the jupyter server in the local machine (`-L 8888:172.21.12.29:888`).
+
+Then, open the connection to the browser in your local machine by following the given link:
+```
+http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
 ```
 
-Jupyter provides you a token to connect to the lab. You can also notice the available kernels.
+The link provides the access token, so you should be able to login without a password.
 
 !!! warning
-    Do not forget to click on the `quit` button when finished to stop the jupyter server and release the resources.
+    Do not forget to click on the `quit` button when finished to stop the jupyter server and release the resources. Note that in the last line of the submission script the job waits for your Jupyter service to finish. 
+
+If you encounter any issues, have a look in the debug output in `Jupyter_<job id>.out`.
+
+??? example "Typical content of ``Jupyter_<job id>.out`"
+    ```shell
+    > cat Jupyter_3776876.out 
+    [I 2024-10-16 15:13:14.150 ServerApp] jupyter_lsp | extension was successfully linked.
+    [I 2024-10-16 15:13:14.154 ServerApp] jupyter_server_terminals | extension was successfully linked.
+    [I 2024-10-16 15:13:14.158 ServerApp] jupyterlab | extension was successfully linked.
+    [I 2024-10-16 15:13:14.346 ServerApp] notebook_shim | extension was successfully linked.
+    [I 2024-10-16 15:13:14.409 ServerApp] notebook_shim | extension was successfully loaded.
+    [I 2024-10-16 15:13:14.412 ServerApp] jupyter_lsp | extension was successfully loaded.
+    [I 2024-10-16 15:13:14.413 ServerApp] jupyter_server_terminals | extension was successfully loaded.
+    [I 2024-10-16 15:13:14.414 LabApp] JupyterLab extension loaded from /home/users/gkafanas/environments/jupyter_env/lib/python3.11/site-packages/jupyterlab
+    [I 2024-10-16 15:13:14.414 LabApp] JupyterLab application directory is /mnt/aiongpfs/users/gkafanas/environments/jupyter_env/share/jupyter/lab
+    [I 2024-10-16 15:13:14.415 LabApp] Extension Manager is 'pypi'.
+    [I 2024-10-16 15:13:14.425 ServerApp] jupyterlab | extension was successfully loaded.
+    [I 2024-10-16 15:13:14.426 ServerApp] Serving notebooks from local directory: /mnt/aiongpfs/users/gkafanas/support/RITM0195641
+    [I 2024-10-16 15:13:14.426 ServerApp] Jupyter Server 2.14.2 is running at:
+    [I 2024-10-16 15:13:14.426 ServerApp] http://172.21.12.29:8888/lab?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
+    [I 2024-10-16 15:13:14.426 ServerApp]     http://127.0.0.1:8888/lab?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
+    [I 2024-10-16 15:13:14.426 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
+    [C 2024-10-16 15:13:14.429 ServerApp] 
+        
+        To access the server, open this file in a browser:
+            file:///mnt/aiongpfs/users/gkafanas/.local/share/jupyter/runtime/jpserver-3804563-open.html
+        Or copy and paste one of these URLs:
+            http://172.21.12.29:8888/lab?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
+            http://127.0.0.1:8888/lab?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
+    [I 2024-10-16 15:13:14.441 ServerApp] Skipped non-installed server(s): bash-language-server, dockerfile-language-server-nodejs, javascript-typescript-langserver, jedi-language-server, julia-language-server, pyright, python-language-server, python-lsp-server, r-languageserver, sql-language-server, texlab, typescript-language-server, unified-language-server, vscode-css-languageserver-bin, vscode-html-languageserver-bin, vscode-json-languageserver-bin, yaml-language-server
+    [I 2024-10-16 15:13:14.518 ServerApp] 302 GET / (@172.21.12.29) 0.51ms
+    
+    ===
+    
+    AVAILABLE LABS
+    
+    Currently running servers:
+    http://172.21.12.29:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2 :: /mnt/aiongpfs/users/gkafanas/support/RITM0195641
+    
+    ===
+    
+    CONFIGURATION PATHS
+    
+    config:
+        /home/users/gkafanas/environments/jupyter_env/etc/jupyter
+        /mnt/aiongpfs/users/gkafanas/.jupyter
+        /usr/local/etc/jupyter
+        /etc/jupyter
+    data:
+        /home/users/gkafanas/environments/jupyter_env/share/jupyter
+        /mnt/aiongpfs/users/gkafanas/.local/share/jupyter
+        /usr/local/share/jupyter
+        /usr/share/jupyter
+    runtime:
+        /mnt/aiongpfs/users/gkafanas/.local/share/jupyter/runtime
+    
+    ===
+    
+    KERNEL SPECIFICATIONS
+    
+    Available kernels:
+      other_python_env    /home/users/gkafanas/environments/jupyter_env/share/jupyter/kernels/other_python_env
+      python3             /home/users/gkafanas/environments/jupyter_env/share/jupyter/kernels/python3
+    slurmstepd: error: *** JOB 3776876 ON aion-0113 CANCELLED AT 2024-10-16T15:25:20 ***
+    [C 2024-10-16 15:25:20.236 ServerApp] received signal 15, stopping
+    [I 2024-10-16 15:25:20.237 ServerApp] Shutting down 4 extensions
+    ```
+
+### Password protected access
+
+You can also set a password when launching the jupyter lab as detailed in the [Jupyter official documentation](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html). In that case, simply direct you browser to the URL `http://127.0.0.1:8888/` and provide your password. You can see bellow an example of the login page.
+
+??? example "Typical content of a password protected login page"
+    ![](./images/jupyter_login.png)
+
+

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -44,18 +44,29 @@ JupyterLab is now installed and ready.
     python -m pip install jupyter ipykernel
     ```
 
-??? info "Managing multiple kernels"
-    JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created.
+### Providing access to kernels of other environments
 
-    You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `~/environments/jupyter_env`:
-    ```shell
-    source ~/environments/other_python_env/bins/activate
-    python -m pip install ipykernel
-    python -m ipykernel install --prefix=~/environments/jupyter_env --name "Other Python env"
-    ```
-    Then all kernels and their associated environment can be start from the same Jupyter instance.
+JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created. Other environments can export a _kernel_ to a JupyterLab instance, allowing the instance to launch interactive session inside environments others from the environment where JupyterLab is installed.
 
-    You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments.
+You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `~/environments/jupyter_env`:
+```shell
+source ~/environments/other_python_venv/bins/activate
+python -m pip install ipykernel
+python -m ipykernel install --prefix=~/environments/jupyter_env --name "Other Python env"
+deactivate
+```
+Then all kernels and their associated environment can be started from the same Jupyter instance in the `~/environments/jupyter_env` Python venv.
+
+You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments for a user.
+
+### Kernels for Conda environments
+
+If you would like to install a kernel in a Conda environment, install the `ipykernel` from the `conda-forge` channel. For instance,
+```bash
+micromamba install --name conda_env conda-forge::ipykernel
+micromamba run --name conda_env python -m ipykernel install --prefix=~/environments/jupyter_env --name "Other Python env"
+```
+will make your conda environment, `conda_env`, available in the kernel launched from the `~/environments/jupyter_env` Python venv.
 
 ## Starting a Jupyter Notebook
 
@@ -147,4 +158,4 @@ Available kernels:
 Jupyter provides you a token to connect to the lab. You can also notice the available kernels.
 
 !!! warning
-    Do not forget to click on the `quit` button when finished to stop the jupyter server and release the ressources.
+    Do not forget to click on the `quit` button when finished to stop the jupyter server and release the resources.


### PR DESCRIPTION
Extend the submission script so that a single Jupyter environment is required to interface with all Python environments. This modification makes the submission script more complex, but simplifies the process of making environments accessible to the Jupyter kernel.