### PR TITLE
Control the text area width

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,4 @@
 /*
-   Time-stamp: <Sun 2021-02-07 22:20 svarrette>
    Extra CSS configuration of the ULHPC Technical Documentation website
  */
 
@@ -8,4 +7,20 @@
 }
 .md-typeset ul li li li{
     list-style: square;
+}
+
+/* Control the width of the text area */
+@media only screen and (min-width: 76.25em) {
+  .md-main__inner {
+    max-width: 24in; /* Use `none` for full width */
+  }
+  .md-sidebar--primary {
+    left: 0;
+  }
+  .md-sidebar--secondary {
+    right: 0;
+    margin-left: 0;
+    -webkit-transform: none;
+    transform: none;   
+  }
 }


### PR DESCRIPTION
Create a custom CSS to control the maximum text area width.]

Some pictures may appear out of proportion and/or position:

- http://127.0.0.1:8000/interconnect/ib/
- http://127.0.0.1:8000/interconnect/ethernet/
- http://127.0.0.1:8000/systems/aion/timeline/

On the other hand, tables with long entries do not break lines inconveniently often:

- http://127.0.0.1:8000/environment/modules/#organization-of-software-set-files-and-manual-selection-of-the-software-set

The image positioning and sizing issues can be solved like in this example: https://squidfunk.github.io/mkdocs-material/reference/images/#image-captions