### PR TITLE
Refactor/modules

### DIFF
--- a/docs/environment/modules.md
+++ b/docs/environment/modules.md
@@ -95,10 +95,9 @@ At the heart of environment modules interaction resides the following components
 
 ??? example "Example of ULHPC `toolchain/foss` (auto-generated) module file"
     ```console
-    $ module show toolchain/foss
-    -----------------------------------------------------------------------------------------------------
-       /opt/apps/easybuild/systems/aion/rhel810-20250216/2023b/epyc/modules/all/toolchain/foss/2023b.lua:
-    -----------------------------------------------------------------------------------------------------
+    ----------------------------------------------------------------------------------------------------------------
+       /opt/apps/easybuild/systems/aion/rhel810-20250405/2023b/epyc/modules/all/toolchain/foss/2023b.lua:
+    ----------------------------------------------------------------------------------------------------------------
     help([[
     Description
     ===========
@@ -121,9 +120,9 @@ At the heart of environment modules interaction resides the following components
     depends_on("numlib/FFTW/3.3.10-GCC-13.2.0")
     depends_on("numlib/FFTW.MPI/3.3.10-gompi-2023b")
     depends_on("numlib/ScaLAPACK/2.2.0-gompi-2023b-fb")
-    setenv("EBROOTFOSS","/opt/apps/easybuild/systems/aion/rhel810-20250216/2023b/epyc/software/foss/2023b")
+    setenv("EBROOTFOSS","/opt/apps/easybuild/systems/aion/rhel810-20250405/2023b/epyc/software/foss/2023b")
     setenv("EBVERSIONFOSS","2023b")
-    setenv("EBDEVELFOSS","/opt/apps/easybuild/systems/aion/rhel810-20250216/2023b/epyc/software/foss/2023b/easybuild/toolchain-foss-2023b-easybuild-devel")
+    setenv("EBDEVELFOSS","/opt/apps/easybuild/systems/aion/rhel810-20250405/2023b/epyc/software/foss/2023b/easybuild/toolchain-foss-2023b-easybuild-devel")
     ```
 
 ## Modules for software sets in UL HPC

--- a/docs/environment/modules.md
+++ b/docs/environment/modules.md
@@ -18,7 +18,7 @@ The main advantages of using an environment module system are the following:
 
 ## Environment modules
 
-Environment module systems are a standard set of tools deployed in most HPC sites to allow dynamic modification of user environments. The [environment module framework](https://modules.sourceforge.net/docs/Modules-Paper.pdf) was fist implement in [Environment Modules](https://modules.sourceforge.net/) in [Tcl](https://www.tcl-lang.org/) and later in other tools such as [Lmod](https://lmod.readthedocs.io/) that is written in [Lua](https://www.lua.org/). All implementations provide the [`module`](http://lmod.readthedocs.io) command to
+Environment module systems are a standard set of tools deployed in most HPC sites to allow dynamic modification of user environments. The [environment module framework](https://modules.sourceforge.net/docs/Modules-Paper.pdf) was fist implement in [Environment Modules](https://modules.sourceforge.net/) in the [Tcl](https://www.tcl-lang.org/) language, and later in other tools such as [Lmod](https://lmod.readthedocs.io/) which is written in [Lua](https://www.lua.org/). All implementations provide the [`module`](http://lmod.readthedocs.io) command to
 
 - manage the `PATH`, `LD_LIBRARY_PATH`, `MANPATH`, and other shell environment variables,
 - define shell functions, and
@@ -30,6 +30,7 @@ By automatically modifying the shell environment, the modules can load and unloa
 - the provision of multiple version of software packages that can co-exists independently in different module environments.
 
 !!! danger "The `module` command is only available on the compute nodes"
+
     There is no environment module system installed in login nodes. This is a deliberate choice to prevent users from running large jobs on login nodes. You need to be within a job (interactive or not) to load modules provided by UL HPC or private modules.
 
 ??? info "Inner working of environment modules systems"
@@ -129,7 +130,7 @@ At the heart of environment modules interaction resides the following components
 
 In UL HPC we are using environment modules to modify the available module set. This is done to prevent accidental mixing of modules from different software sets. To load a set of software modules, simply load the appropriate module the modifies the available software set. There are two types of software sets.
 
-- _Modules under_ `env`: this is a set of modules [sticky](https://lmod.readthedocs.io/en/latest/240_sticky_modules.html) optimized for the UL HPC systems. The modules are designed to load a different natively optimized set of modules for each system in UL HPC.
+- _Modules under_ `env`: this is a set of [sticky](https://lmod.readthedocs.io/en/latest/240_sticky_modules.html) modules optimized for the UL HPC systems. The modules are designed to load a different natively optimized set of modules for each system in UL HPC.
 - _Modules under_ [`EESSI`](/software/eessi): this modules load EESSI software sets. The software sets distributed under EESSI are generically optimized software sets for a number of architectures that are designed to support reproducibility and are available across multiple HPC centers.
 
 !!! important "When to use EESSI"


### PR DESCRIPTION
A slight modification to the method for loading default modules. Now users can select a set of default modules by setting the `LMOD_SYSTEM_DEFAULT_MODULES` environment variable. The empty set is selected with the empty string value.