### PR TITLE
Refactor Jupyter and SSH pages

### DIFF
--- a/docs/connect/ssh.md
+++ b/docs/connect/ssh.md
@@ -399,7 +399,7 @@ See [the corresponding section](troubleshooting.md).
 
 ### CLI Completion
 
-The `bash-completion` package eases the ssh command usage by providing completion for hostnames and more (assuming you set the directive `HashKnownHost` to `no` in your `~/etc/ssh_config`)
+The `bash-completion` package eases the ssh command usage by providing completion for hostnames and more (assuming you set the directive `HashKnownHost` to `no` in your `~/etc/ssh_config`).
 
 ### SOCKS 5 Proxy plugin
 

--- a/docs/connect/ssh.md
+++ b/docs/connect/ssh.md
@@ -575,38 +575,55 @@ By using the `-g` parameter, you allow connections from other hosts than localho
 Compute nodes are not directly accessible from the outside network. To login into a cluster node you will need to jump through a login node. Remember, you need a job running in a node before you can ssh into it. Assume that you have some job running on `aion-0014` for instance. Then, connect to `aion-0014` with,
 
 ```bash
-ssh -J ${CLUSTER_USER}@access-aion.uni.lu:8022 ${CLUSTER_USER}@aion-0014
+ssh -J ${USER}@access-aion.uni.lu:8022 ${USER}@aion-0014
 ```
 
-where `CLUSTER_USER` is your username in UL HPC clusters. The domain resolution in the login node will determine the IP of the `aion-0014`. You can always use the IP address of the node directly.
+where `USER` is a variable containing your username in UL HPC clusters. The domain resolution in the login node will determine the IP of the `aion-0014`. You can always use the IP address of the node directly.
 
-!!! tip "Obtaining the IP address of cluster nodes"
+??? tip "Obtaining the IP address of cluster nodes"
     To get the IP address of any node just run the following command.
 
     ```bash
     hostname --ip-address
     ```
 
+??? tip "Useful environment variables for SSH jumps"
+    - `USER`: In most Linux systems the `USER` environment variable is defined in the `/etc/profile` and `/etc/prifile.d/*` scripts, and contains the username of the user.
+    - `HOSTNAME`: A shell variable defined in BASH that contains the name of the host machine.
+    - `ULHPC_CLUSTER`: An environment variable defined in environment initialization scripts of UL HPC, and contains and identifier of the system, `aion` or `iris`.
+
+
 #### Authorizing access to compute nodes
 
-In UL HPC clusters, the authorization for logging into the login nodes is not provided by the `authorized_keys` file, but by [identity management](/connect/ipa/) system. However, connection to the compute nodes are authorized by the `authorized_keys` file. Thus, to be able to jump to compute nodes, just append your public key to the
-
-```
-${HOME}/.ssh/authorized_keys
-```
-
-file in the UL HPC cluster, creating the file if it does not already exist. There is an SSH command to automate this error prone process. Just call 
+In UL HPC clusters, the authorization for logging into the login nodes is not provided by the `authorized_keys` file, but by [identity management](/connect/ipa/) system. However, connections to the compute nodes are authorized by the `authorized_keys` file. Use the command
 
 ```
 ssh-copy-id -i <private key> aion-cluster
 ```
 
-in your local machine, where the `<private key>` is the private key for the public key you would like to copy to the UL HPC cluster. For instance `<private key> = ~/.ssh/id_ed25519` for the default ED25519 key pair.
+if you have [configured SSH](#ssh-configuration), or
+
+```
+ssh-copy-id -i <private key> -p 8022 <user name>@access-aion.uni.lu
+```
+
+if you haven't; the `<private key>` is the private key for the public key you would like to copy to the UL HPC cluster. For instance,
+
+-  `<private key>` is `~/.ssh/id_ed25519` for the default ED25519 key pair, and
+-  `<private key>` is `~/.ssh/id_rsa` for the default RSA key pair.
 
 !!! tip "Passwordless SSH jumps"
     With a proxy jump command SSH logs into the jump host, initiates I/O forwarding, and then logs into the target remote host using the credentials of your local machine. Thus, the `ProxyJump` SSH option [obviates the need for SSH agent forwarding](https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Proxies_and_Jump_Hosts#Old:_Recursively_Chaining_Gateways_Using_stdio_Forwarding). You do not need SSH agent forwarding to the jump host or the target remote host, just ensure that your private key is authorized both in the jump hosts and in the target remote host.
 
     You still need to run the [SSH agent](#ssh-agent) in your local machine to ensure passwordless to keys protected by passphrase.
+
+??? tip "the `authorized_keys` file"
+    The `authorized_keys` file is located in 
+    ```
+    ${HOME}/.ssh/authorized_keys
+    ```
+    and `ssh-copy-id` simply automatically appends the key at the end of the file in the remote host.
+
 
 #### Port forwarding over SSH jumps
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -64,7 +64,41 @@ ${HOME}/.local/share/jupyter/kernels/notebook_venv
 
 and will appear with the name "Notebook" in the list of available kernels in all Jupyter applications launched by the user.
 
-### Kernels in environments with site packages
+??? info "Kernels in arbitrary directories"
+
+    Kernels can be installed in arbitrary directories. For instance you store kernels in a [project directory](/filesystems/#project-directories) to share them with other members of your team. In this case use the `--prefix` option when creating the kernel.
+
+    ```shell
+    module load lang/Python
+    source ${HOME}/environments/notebook_venv/bin/activate
+    python -m ipykernel install --prefix=${PROJECTHOME}/project_name/environments/jupyter_env --name notebook_venv --display-name "Notebook"
+    deactivate
+    ```
+
+    To use a kernel from a custom installation path instruct the Jupyter application to search for environments in the extra path with the `--notebook-dir` option. For instance with the command
+
+    ```shell
+    module load tools/JupyterLab
+    jupyter lab --notebook-dir=${PROJECTHOME}/project_name/environments/jupyter_env
+    ```
+
+    the "Notebook" will be listed in the available kernels in the Jupyter lab application.
+
+??? info "Kernels for Conda environments"
+
+    Some packages may require a specific version of Python. In this case install the required Python version in a Conda environment. Then follow the steps above to create the Python environment while using the Python of the Conda environment. For instance, the commands
+    ```bash
+    micromamba create --name conda_notebook conda-forge::python=3.8
+    micromamba run --name conda_notebook python -m venv ${HOME}/environments/conda_notebook_venv
+    source ${HOME}/environments/conda_notebook_vemv/bin/activate
+    python -m ipykernel install --user --name conda_notebook_venv --display-name "Conda notebook"
+    deactivate
+    ```
+    create a kernel for the `conda_notebook_venv` environment with Python 3.8.
+
+    Note that Jupyter does not currently support kernels for Conda environments, so you have to create a Python environment (`venv`) for your kernel.
+
+### Environments with site packages
 
 The UL HPC systems offer optimized Python packages for applications such as PyTorch. You can access the optimized packages in your environments if you build your environment with access to system site packages. For instance to access the PyTorch packages that have been optimized for GPUs in the Iris GPU nodes create the environment for your notebook as follows.
 
@@ -78,40 +112,6 @@ deactivate
 ```
 
 With the `--system-site-packages` flag, the packages provided by the `ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0` module are accessible inside the `notebook_venv` environment.
-
-### Kernels in arbitrary directories
-
-Kernels can be installed in arbitrary directories. For instance you store kernels in a [project directory](/filesystems/#project-directories) to share them with other members of your team. In this case use the `--prefix` option when creating the kernel.
-
-```shell
-module load lang/Python
-source ${HOME}/environments/notebook_venv/bin/activate
-python -m ipykernel install --prefix=${PROJECTHOME}/project_name/environments/jupyter_env --name notebook_venv --display-name "Notebook"
-deactivate
-```
-
-To use a kernel from a custom installation path instruct the Jupyter application to search for environments in the extra path with the `--notebook-dir` option. For instance with the command
-
-```shell
-module load tools/JupyterLab
-jupyter lab --notebook-dir=${PROJECTHOME}/project_name/environments/jupyter_env
-```
-
-the "Notebook" will be listed in the available kernels in the Jupyter lab application.
-
-### Kernels for Conda environments
-
-Some packages may require a specific version of Python. In this case install the required Python version in a Conda environment. Then follow the steps above to create the Python environment while using the Python of the Conda environment. For instance, the commands
-```bash
-micromamba create --name conda_notebook conda-forge::python=3.8
-micromamba run --name conda_notebook python -m venv ${HOME}/environments/conda_notebook_venv
-source ${HOME}/environments/conda_notebook_vemv/bin/activate
-python -m ipykernel install --user --name conda_notebook_venv --display-name "Conda notebook"
-deactivate
-```
-create a kernel for the `conda_notebook_venv` environment with Python 3.8.
-
-Note that Jupyter does not currently support kernels for Conda environments, so you have to create a Python environment (`venv`) for your kernel.
 
 
 ## Working with JupyterLab

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -235,14 +235,20 @@ to connect to the notebook from your laptop. Open a terminal on your laptop and 
     http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
     ```
 
-As the instructions suggest, you access the jupyter lab server in the compute node by calling
+As the instructions suggest, you access the jupyter lab server in the compute node by the following [SSH jump command](/connect/ssh/#ssh-jumps).
 ```shell
 ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
 ```
-an SSH command that
 
-- opens a connection to your allocated cluster node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
-- exports the port to the jupyter server in the local machine (`-L 8888:127.0.0.1:8888`).
+??? info "TL;DR: SSH jump"
+    The [SSH jump command](/connect/ssh/#ssh-jumps) command,
+
+    ```shell
+    ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
+    ```
+
+    - opens a connection to your allocated cluster node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
+    - exports the port to the jupyter server in the local machine (`-L 8888:127.0.0.1:8888`).
 
 Then, open the connection to the browser in your local machine by following the given link:
 ```

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -21,9 +21,9 @@ We strongly recommend using the Jupyter application provided through [modules](/
 
 ### Kernels
 
-Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute the code of the notebook. You can host kernels on isolated Python environments or on the environment of the notebook. Whenever possible use the Python [module](/environment/modules/) to create your Python environments. Modules have been configured for optimal performance in our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
+Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute the code of the notebook. Jupyter applications provide a default [IPython](https://ipython.readthedocs.io/en/stable/) kernel in the environment where Jupyer lab runs. Other environments can export a _kernel_ to a Jupyter application instances, allowing each instance to launch interactive session inside environments others than the environment where Jupyter application is installed.
 
-To create a Python environment for your kernel, start by loading the Python module and then create the environment. 
+Whenever possible use the Python [module](/environment/modules/) to create your Python environments. Modules have been configured for optimal performance in our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools. To create a Python environment for your kernel, start by loading the Python module and then create the environment.
 
 ```shell
 module load lang/Python
@@ -417,22 +417,4 @@ After installing your required version of JupyterLab, you can install your packa
     pip install jupyter ipykernel
     ```
     in the creation of the `jupyter_env` Python environment.
-
-### Providing access to kernels of other environments
-
-JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created. Other environments can export a _kernel_ to a JupyterLab instance, allowing the instance to launch interactive session inside environments others from the environment where JupyterLab is installed.
-
-You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `${HOME}/environments/jupyter_env`:
-```shell
-source ${HOME}/environments/other_python_venv/bin/activate
-python -m pip install ipykernel
-python -m ipykernel install --prefix=${HOME}/environments/jupyter_env --name other_python_env --display-name "Other Python env"
-deactivate
-```
-Then all kernels and their associated environment can be started from the same Jupyter instance in the `${HOME}/environments/jupyter_env` Python venv.
-
-You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments for a user.
-
-
-
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -2,9 +2,9 @@
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Jupyter_logo.svg/1200px-Jupyter_logo.svg.png){: style="width:300px;float: right;"}
 
-[Jupyter](https://jupyter.org/) is a set of free software, open standards, and web services for interactive computing across all programming languages. Jupyter is a large umbrella project that covers many different software offerings and tools, including the popular Jupyter Notebook and JupyterLab web-based notebook authoring and editing applications. The Jupyter project and its subprojects all center around providing tools (and standards) for interactive computing with computational [notebooks](#notebooks).
+[Jupyter](https://jupyter.org/) is a large umbrella project that covers many different software offerings and tools, including the popular Jupyter Notebook and JupyterLab web-based notebook authoring and editing applications. The Jupyter project and its subprojects all center around providing tools and standards for interactive computing with computational [notebooks](#notebooks). The set of free software, open standards, and web services supported by Jupyter can be used to implement interactive computing in notebooks across any programming language.
 
-We strongly recommend using [modules](/environment/modules/) for Jupter application whenever modules are available. The main applications for interacting with Jupyter notebooks that are supported in UL HPC systems through modules are the following.
+We strongly recommend using the Jupyter application provided through [modules](/environment/modules/) whenever possible. The applications for interacting with Jupyter notebooks that are supported in UL HPC systems through modules are the following.
 
 - [JupyterLab](https://jupyterlab.readthedocs.io/en/latest/) provided by `tools/JupyterLab`: a web-based interactive development environment for notebooks, code, and data; typically used to develop notebook documents.
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -1,74 +1,123 @@
-# Jupyter Notebook
+# Jupyter
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Jupyter_logo.svg/1200px-Jupyter_logo.svg.png){: style="width:300px;float: right;"}
 
+[Jupyter](https://jupyter.org/) is a set of free software, open standards, and web services for interactive computing across all programming languages. Jupyter is a large umbrella project that covers many different software offerings and tools, including the popular Jupyter Notebook and JupyterLab web-based notebook authoring and editing applications. The Jupyter project and its subprojects all center around providing tools (and standards) for interactive computing with computational [notebooks](#notebooks).
 
-[JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) is a flexible, popular literate-computing web application for creating notebooks containing code, equations, visualization, and text. Notebooks are documents that contain both computer code and rich text elements (paragraphs, equations, figures, widgets, links). They are human-readable documents containing analysis descriptions and results but are also executable data analytics artifacts. Notebooks are associated with kernels, processes that actually execute code. Notebooks can be shared or converted into static HTML documents. They are a powerful tool for reproducible research and teaching.
+We strongly recommend using [modules](/environment/modules/) for Jupter application whenever modules are available. The main applications for interacting with Jupyter notebooks that are supported in UL HPC systems through modules are the following.
 
+- [JupyterLab](https://jupyterlab.readthedocs.io/en/latest/) provided by `tools/JupyterLab`: a web-based interactive development environment for notebooks, code, and data; typically used to develop notebook documents.
 
-## Install Jupyter
+- [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/latest/) provided by `tools/JupyterNotebook`: a notebook authoring application; notebooks are shareable document that combines computer code, plain language descriptions, data, and visualizations.
 
-While JupyterLab runs code in Jupyter notebooks for many programming languages, Python is a requirement (Python 3.3 or greater, or Python 2.7) for installing the JupyterLab. New users may wish to install JupyterLab in a Conda environment. Hereafter, the `pip` package manager will be used to install JupyterLab.
-
-We strongly recommend to use the Python module provided by the ULHPC and installing `jupyter` inside a Python virtual environment after upgrading `pip`.
-
-```shell
-$ si
-$ module load lang/Python #Loading default Python
-$ python -m venv ~/environments/jupyter_env
-$ source ~/environments/jupyter_env/bin/activate
-$ python -m pip install --upgrade pip
-$ python -m pip install jupyterlab
-```
+-  [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) provided by `tools/JupyterHub`: a multi-user Hub that spawns and manages multiple instances of the single-user Jupyter notebook server; useful for sharing multiple instances of a notebook to a group of users.
 
 !!! warning
-    Modules are not allowed on the access servers. To test interactively Singularity, remember to ask for an [interactive job](/jobs/interactive) first using  for instance the `si` tool.
+    Modules are not allowed on the access servers. To test interactively, remember to ask for an [interactive job](/jobs/interactive) first using  for instance the `si` tool.
 
-Once JupyterLab is installed along with , you can start to configure your installation setting the environment variables corresponding to your needs:
+## Notebooks
 
-- `JUPYTER_CONFIG_DIR`: Set this environment variable to use a particular directory, other than the default, for Jupyter config files
-- `JUPYTER_PATH`: Set this environment variable to provide extra directories for the data search path. `JUPYTER_PATH` should contain a series of directories, separated by os.pathsep(; on Windows, : on Unix). Directories given in JUPYTER_PATH are searched before other locations. This is used in addition to other entries, rather than replacing any
-- `JUPYTER_DATA_DIR`: Set this environment variable to use a particular directory, other than the default, as the user data directory
-- `JUPYTER_RUNTIME_DIR`: Set this to override where Jupyter stores runtime files
-- `IPYTHONDIR`: If set, this environment variable should be the path to a directory, which IPython will use for user data. IPython will create it if it does not exist.
+[Notebooks](https://docs.jupyter.org/en/latest/#what-is-a-notebook) are documents that contain computer code, data, and rich text elements such as normal test, graphical equations, links, figures, and widgets. Notebooks contain human-readable analysis, descriptions, and results, together with executable versions of code data. As a result, notebooks are particularly popular for data analytics jobs, where they allow the interactive development of reproducible data analytic pipelines. Notebooks can be shared or converted into static HTML documents, and they are thus a powerful teaching tool as well.
 
-JupyterLab is now installed and ready.
+Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute code required for the notebook. You can host kernels in isolated Python environments. Whenever possible use the Python [module](/environment/modules/) provided to create your environment, as modules have been optimally configured for our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
 
-??? info "Installing the classic Notebook"
-    JupyterLab (`jupyterlab`) is a new package which automates many task that where performed manually in the traditional Jupyter package (`jupyter`). If you prefer to install the classic notebook, you also need to install the [IPython](https://ipython.readthedocs.io/en/stable/index.html) manually as well, replacing
-    ```bash
-    python -m pip install jupyterlab
-    ```
-    with:
-    ```bash
-    python -m pip install jupyter ipykernel
-    ```
+To create the Python environment, start by loading the Python module and then create the environment. 
 
-### Providing access to kernels of other environments
-
-JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created. Other environments can export a _kernel_ to a JupyterLab instance, allowing the instance to launch interactive session inside environments others from the environment where JupyterLab is installed.
-
-You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `~/environments/jupyter_env`:
 ```shell
-source ~/environments/other_python_venv/bin/activate
-python -m pip install ipykernel
-python -m ipykernel install --prefix=${HOME}/environments/jupyter_env --name other_python_env --display-name "Other Python env"
+module load lang/Python
+python -m venv ~/environments/notebook_venv
+```
+
+Install the packages that you require in your environment, and then install the `ipykernel` package.
+
+```shell
+module load lang/Python
+source ~/environments/notebook_venv/bin/activate
+pip install ipykernel
 deactivate
 ```
-Then all kernels and their associated environment can be started from the same Jupyter instance in the `~/environments/jupyter_env` Python venv.
 
-You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments for a user.
+You can then export a kernel for your environment that Jupyter applications can use to create notebooks using the environment. Jupyter applications provide a default environment with a kernel and also search some default locations for additional kernels. The user default location selected with the `--user` option of `ipykernel` is:
+
+```
+${HOME}/.local/share/jupyter/kernels
+```
+
+With the command,
+
+```shell
+module load lang/Python
+source ~/environments/notebook_venv/bin/activate
+python -m ipykernel install --user --name notebook_venv --display-name "Notebook"
+deactivate
+```
+
+the kernel will be created in the default user location:
+
+```
+${HOME}/.local/share/jupyter/kernels/notebook_venv
+```
+
+and the kernel will appear with the name "Notebook" in your list of available kernels in all Jupyter applications launched by the user.
+
+### Kernels in environments with site packages
+
+The UL HPC systems offer optimized Python packages for applications such as PyTorch. You can access the optimized packages in your environments if you build your environment with access to system site packages. For instance to access the PyTorch packages that have been optimized for GPUs in the Iris GPU nodes create the environment for your notebook as follows.
+
+```shell
+module load ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0
+python -m venv --system-site-packages ~/environments/notebook_venv
+source ~/environments/notebook_venv/bin/activate
+pip install ipykernel
+python -m ipykernel install --user --name notebook_venv --display-name "Notebook"
+deactivate
+```
+
+With the `--system-site-packages` flag, the packages provided by the `ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0` module are accessible to your `notebook_venv`.
+
+### Kernels in arbitrary directories
+
+You can also specify an installation location for your kernel that is different than the default user location. For instance you may want to store your kernel in a [project directory](/filesystems/#project-directories) to share it with other members of your team. In this case you can use the `--prefix` option to create the project.
+
+```shell
+module load lang/Python
+source ~/environments/notebook_venv/bin/activate
+python -m ipykernel install --prefix=${PROJECTHOME}/project_name/environments/jupyter_env --name notebook_venv --display-name "Notebook"
+deactivate
+```
+
+To use a kernel from a custom installation path instruct the Jupyter application to search for environments in the extra path with the `--notebook-dir` option. For instance with the command
+
+```shell
+module load tools/JupyterLab
+jupyter lab --notebook-dir=${PROJECTHOME}/project_name/environments/jupyter_env
+```
+
+the "Notebook" will be listed in the available kernels in the Jupyter lab application.
 
 ### Kernels for Conda environments
 
-If you would like to install a kernel in a Conda environment, install the `ipykernel` from the `conda-forge` channel. For instance,
+Some packages may require a specific version of Python. In this case install the required Python version in a Conda environment. Then follow the steps above to create the Python environment while using the Python of the Conda environment. For instance, the commands
 ```bash
-micromamba install --name conda_env conda-forge::ipykernel
-micromamba run --name conda_env python -m ipykernel install --prefix=${HOME}/environments/jupyter_env --name other_python_env --display-name "Other Python env"
+micromamba create --name conda_notebook conda-forge::python=3.8
+micromamba run --name conda_notebook python -m venv ~/environments/conda_notebook_venv
+source ~/environments/conda_notebook_vemv/bin/activate
+python -m ipykernel install --user --name conda_notebook_venv --display-name "Conda notebook"
+deactivate
 ```
-will make your conda environment, `conda_env`, available in the kernel launched from the `~/environments/jupyter_env` Python venv.
+create a kernel for the `conda_notebook_venv` environment with Python 3.8.
 
-## Starting a Jupyter Notebook
+Note that Jupyter does not currently support kernels for Conda environments, so you have to create a Python environment (`venv`) for your kernel.
+
+
+## Working with JupyterLab
+
+[JupyterLab](https://jupyterlab.readthedocs.io/en/latest/) is a web-based interactive development environment for notebooks, code, and data. Typically used to develop notebook documents, is highly extensible, and more feature-rich that the traditional Jupyter Notebook. In UL HPC systems Jupyter lab is provided by the `tools/JupyterLab` [module](/environment/modules/). Load the Jupyter module with the following command.
+
+```shell
+module load tools/JupyterLab
+```
+### Starting a JupyterLab session
 
 Jupyter notebooks must be started as [slurm jobs](/jobs/submit). The following script is a template for Jupyter submission scripts that will rarely need modifications. Most often you will need to modify the session duration (`--time` SBATCH option).
 
@@ -88,9 +137,8 @@ Jupyter notebooks must be started as [slurm jobs](/jobs/submit). The following s
     print_error_and_exit() { echo "***ERROR*** $*"; exit 1; }
     module purge || print_error_and_exit "No 'module' command"
     
-    # Load the default Python 3 module
-    module load lang/Python
-    source "${HOME}/environments/jupyter_env/bin/activate"
+    # Load the JupyterLab module
+    module load tools/JupyterLab
 
     declare loopback_device="127.0.0.1"
     declare port="8888"
@@ -260,11 +308,67 @@ If you encounter any issues, have a look in the debug output in `Jupyter_<job id
       python3             /home/users/gkafanas/environments/jupyter_env/share/jupyter/kernels/python3 
     ```
 
+### Environment configuration
+
+Jupyter generates various files during runtime, and reads configuration files from various locations. You can control these paths using [environment variables](https://docs.jupyter.org/en/latest/use/jupyter-directories.html). For instance, you may set the `JUPYTER_RUNTIME_DIR` to point somewhere in the [`/tmp` directory](https://hpc-docs.uni.lu/filesystems/#intended-usage-of-file-systems) for better performance.
+
+- [`JUPYTER_CONFIG_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_CONFIG_DIR): Set the directory for Jupyter config files; default is `${HOME}/.jupyter`.
+- [`JUPYTER_PATH`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_PATH): Extra directories to search for installable data files, such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter) and [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/); should contain a series of directories, separated by `os.pathsep` (`;` on Windows and `:` on Unix); directories given in `JUPYTER_PATH` are searched before other locations.
+- [`JUPYTER_DATA_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_DATA_DIR): Set the user data directory which contains files such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter), [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/), or [voila templates](https://voila.readthedocs.io/en/stable/index.html); default is `${HOME}/.local/share/jupyter/` (respects `${XDG_DATA_HOME}`).
+- [`JUPYTER_RUNTIME_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_RUNTIME_DIR): Set the location where Jupyter stores runtime files, such as connection files, which are only useful for the lifetime of a particular process; default is `${JUPYTER_DATA_DIR}/runtime`.
+
 ### Password protected access
 
 You can also set a password when launching the jupyter lab as detailed in the [Jupyter official documentation](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html). In that case, simply direct you browser to the URL `http://127.0.0.1:8888/` and provide your password. You can see bellow an example of the login page.
 
 ??? example "Typical content of a password protected login page"
     ![](./images/jupyter_login.png)
+
+
+## Install Jupyter
+
+While JupyterLab runs code in Jupyter notebooks for many programming languages, Python is a requirement (Python 3.3 or greater, or Python 2.7) for installing the JupyterLab. New users may wish to install JupyterLab in a Conda environment. Hereafter, the `pip` package manager will be used to install JupyterLab.
+
+We strongly recommend to use the Python module provided by the ULHPC and installing `jupyter` inside a Python virtual environment after upgrading `pip`.
+
+```shell
+$ si
+$ module load lang/Python #Loading default Python
+$ python -m venv ~/environments/jupyter_env
+$ source ~/environments/jupyter_env/bin/activate
+$ python -m pip install --upgrade pip
+$ python -m pip install jupyterlab
+```
+
+Once JupyterLab is installed along with , you can start to configure your installation setting the environment variables corresponding to your needs.
+
+JupyterLab is now installed and ready.
+
+??? info "Installing the classic Notebook"
+    JupyterLab (`jupyterlab`) is a new package which automates many task that where performed manually in the traditional Jupyter package (`jupyter`). If you prefer to install the classic notebook, you also need to install the [IPython](https://ipython.readthedocs.io/en/stable/index.html) manually as well, replacing
+    ```bash
+    python -m pip install jupyterlab
+    ```
+    with:
+    ```bash
+    python -m pip install jupyter ipykernel
+    ```
+
+### Providing access to kernels of other environments
+
+JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created. Other environments can export a _kernel_ to a JupyterLab instance, allowing the instance to launch interactive session inside environments others from the environment where JupyterLab is installed.
+
+You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `~/environments/jupyter_env`:
+```shell
+source ~/environments/other_python_venv/bin/activate
+python -m pip install ipykernel
+python -m ipykernel install --prefix=${HOME}/environments/jupyter_env --name other_python_env --display-name "Other Python env"
+deactivate
+```
+Then all kernels and their associated environment can be started from the same Jupyter instance in the `~/environments/jupyter_env` Python venv.
+
+You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments for a user.
+
+
 
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -25,14 +25,14 @@ To create the Python environment, start by loading the Python module and then cr
 
 ```shell
 module load lang/Python
-python -m venv ~/environments/notebook_venv
+python -m venv ${HOME}/environments/notebook_venv
 ```
 
 Install the packages that you require in your environment, and then install the `ipykernel` package.
 
 ```shell
 module load lang/Python
-source ~/environments/notebook_venv/bin/activate
+source ${HOME}/environments/notebook_venv/bin/activate
 pip install ipykernel
 deactivate
 ```
@@ -47,7 +47,7 @@ With the command,
 
 ```shell
 module load lang/Python
-source ~/environments/notebook_venv/bin/activate
+source ${HOME}/environments/notebook_venv/bin/activate
 python -m ipykernel install --user --name notebook_venv --display-name "Notebook"
 deactivate
 ```
@@ -66,8 +66,8 @@ The UL HPC systems offer optimized Python packages for applications such as PyTo
 
 ```shell
 module load ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0
-python -m venv --system-site-packages ~/environments/notebook_venv
-source ~/environments/notebook_venv/bin/activate
+python -m venv --system-site-packages ${HOME}/environments/notebook_venv
+source ${HOME}/environments/notebook_venv/bin/activate
 pip install ipykernel
 python -m ipykernel install --user --name notebook_venv --display-name "Notebook"
 deactivate
@@ -81,7 +81,7 @@ You can also specify an installation location for your kernel that is different 
 
 ```shell
 module load lang/Python
-source ~/environments/notebook_venv/bin/activate
+source ${HOME}/environments/notebook_venv/bin/activate
 python -m ipykernel install --prefix=${PROJECTHOME}/project_name/environments/jupyter_env --name notebook_venv --display-name "Notebook"
 deactivate
 ```
@@ -100,8 +100,8 @@ the "Notebook" will be listed in the available kernels in the Jupyter lab applic
 Some packages may require a specific version of Python. In this case install the required Python version in a Conda environment. Then follow the steps above to create the Python environment while using the Python of the Conda environment. For instance, the commands
 ```bash
 micromamba create --name conda_notebook conda-forge::python=3.8
-micromamba run --name conda_notebook python -m venv ~/environments/conda_notebook_venv
-source ~/environments/conda_notebook_vemv/bin/activate
+micromamba run --name conda_notebook python -m venv ${HOME}/environments/conda_notebook_venv
+source ${HOME}/environments/conda_notebook_vemv/bin/activate
 python -m ipykernel install --user --name conda_notebook_venv --display-name "Conda notebook"
 deactivate
 ```
@@ -334,8 +334,8 @@ We strongly recommend to use the Python module provided by the ULHPC and install
 ```shell
 $ si
 $ module load lang/Python #Loading default Python
-$ python -m venv ~/environments/jupyter_env
-$ source ~/environments/jupyter_env/bin/activate
+$ python -m venv ${HOME}/environments/jupyter_env
+$ source ${HOME}/environments/jupyter_env/bin/activate
 $ python -m pip install --upgrade pip
 $ python -m pip install jupyterlab
 ```
@@ -358,14 +358,14 @@ JupyterLab is now installed and ready.
 
 JupyterLab makes sure that a default [IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html#) is available, with the environment (and the Python version) with which the lab was created. Other environments can export a _kernel_ to a JupyterLab instance, allowing the instance to launch interactive session inside environments others from the environment where JupyterLab is installed.
 
-You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `~/environments/jupyter_env`:
+You can [setup kernels with different environments on the same notebook](https://ipython.readthedocs.io/en/stable/install/kernel_install.html). Create the environment with the Python version and the packages you require, and then register the kernel in any environment with Jupyter (lab or classic notebook) installed. For instance, if we have installed Jupyter in `${HOME}/environments/jupyter_env`:
 ```shell
-source ~/environments/other_python_venv/bin/activate
+source ${HOME}/environments/other_python_venv/bin/activate
 python -m pip install ipykernel
 python -m ipykernel install --prefix=${HOME}/environments/jupyter_env --name other_python_env --display-name "Other Python env"
 deactivate
 ```
-Then all kernels and their associated environment can be started from the same Jupyter instance in the `~/environments/jupyter_env` Python venv.
+Then all kernels and their associated environment can be started from the same Jupyter instance in the `${HOME}/environments/jupyter_env` Python venv.
 
 You can also use the flag `--user` instead of `--prefix` to install the kernel in the default system location available to all Jupyter environments for a user.
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -17,11 +17,11 @@ We strongly recommend using the Jupyter application provided through [modules](/
 
 ## Notebooks
 
-[Notebooks](https://docs.jupyter.org/en/latest/#what-is-a-notebook) are documents that contain computer code, data, and rich text elements such as normal test, graphical equations, links, figures, and widgets. Notebooks contain human-readable analysis, descriptions, and results, together with executable versions of code data. As a result, notebooks are particularly popular for data analytics jobs, where they allow the interactive development of reproducible data analytic pipelines. Notebooks can be shared or converted into static HTML documents, and they are thus a powerful teaching tool as well.
+[Notebooks](https://docs.jupyter.org/en/latest/#what-is-a-notebook) are documents that contain computer code, data, and rich text elements such as normal test, graphical equations, links, figures, and widgets. The main advantage of Notebooks is that the concentrate human-readable analysis, descriptions, and results, together with executable versions of code data in a single document. As a result, notebooks are particularly popular for exploratory data analysis, where they allow the interactive development of reproducible data analytic pipelines. Notebooks can be shared or converted into static HTML documents, and they are thus a powerful teaching tool too.
 
-Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute code required for the notebook. You can host kernels in isolated Python environments. Whenever possible use the Python [module](/environment/modules/) provided to create your environment, as modules have been optimally configured for our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
+Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute the code of the notebook. You can host kernels on isolated Python environments or on the environment of the notebook. Whenever possible use the Python [module](/environment/modules/) to create your environment. Modules have been configured for optimal performance in our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
 
-To create the Python environment, start by loading the Python module and then create the environment. 
+To create a Python environment for your kernel, start by loading the Python module and then create the environment. 
 
 ```shell
 module load lang/Python
@@ -37,7 +37,7 @@ pip install ipykernel
 deactivate
 ```
 
-You can then export a kernel for your environment that Jupyter applications can use to create notebooks using the environment. Jupyter applications provide a default environment with a kernel and also search some default locations for additional kernels. The user default location selected with the `--user` option of `ipykernel` is:
+You can then export a kernel for your environment that Jupyter applications can use to create notebooks for the environment. Jupyter applications provide a default environment with a kernel and also search some default locations for additional kernels. The user default location is selected with the `--user` option of `ipykernel` and is located in:
 
 ```
 ${HOME}/.local/share/jupyter/kernels
@@ -58,7 +58,7 @@ the kernel will be created in the default user location:
 ${HOME}/.local/share/jupyter/kernels/notebook_venv
 ```
 
-and the kernel will appear with the name "Notebook" in your list of available kernels in all Jupyter applications launched by the user.
+and will appear with the name "Notebook" in the list of available kernels in all Jupyter applications launched by the user.
 
 ### Kernels in environments with site packages
 
@@ -73,11 +73,11 @@ python -m ipykernel install --user --name notebook_venv --display-name "Notebook
 deactivate
 ```
 
-With the `--system-site-packages` flag, the packages provided by the `ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0` module are accessible to your `notebook_venv`.
+With the `--system-site-packages` flag, the packages provided by the `ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0` module are accessible inside the `notebook_venv` environment.
 
 ### Kernels in arbitrary directories
 
-You can also specify an installation location for your kernel that is different than the default user location. For instance you may want to store your kernel in a [project directory](/filesystems/#project-directories) to share it with other members of your team. In this case you can use the `--prefix` option to create the project.
+Kernels can be installed in arbitrary directories. For instance you store kernels in a [project directory](/filesystems/#project-directories) to share them with other members of your team. In this case use the `--prefix` option when creating the kernel.
 
 ```shell
 module load lang/Python

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -100,7 +100,7 @@ and will appear with the name "Notebook" in the list of available kernels in all
 
 ### Environments with site packages
 
-The UL HPC systems offer optimized Python packages for applications such as PyTorch. You can access the optimized packages in your environments if you build your environment with access to system site packages. For instance to access the PyTorch packages that have been optimized for GPUs in the Iris GPU nodes create the environment for your notebook as follows.
+The UL HPC systems offer optimized Python packages for applications such as PyTorch. You can access the optimized packages in your environments if you build your environment with access to system site packages. For instance, to access the PyTorch packages that have been optimized for GPUs in the Iris GPU nodes create the environment for your notebook as follows.
 
 ```shell
 module load ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0
@@ -112,6 +112,13 @@ deactivate
 ```
 
 With the `--system-site-packages` flag, the packages provided by the `ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0` module are accessible inside the `notebook_venv` environment.
+
+!!! warning "Using environments with system site packages"
+    Before using an environment with system site packages, remember to load the module that provides the system site packages. For instance, in our example, you need to load the PyTorch module
+    ```
+    module load ai/PyTorch/2.3.0-foss-2023b-CUDA-12.6.0
+    ```
+    before using the "Notebook" kernel.
 
 
 ## Working with JupyterLab
@@ -143,6 +150,10 @@ Jupyter notebooks must be started as [slurm jobs](/jobs/submit). The following s
     
     # Load the JupyterLab module
     module load tools/JupyterLab
+    #######################################################################
+    # IF THE KERNEL YOU UARE PLANNING TO USE IS USING SITE PACKAGES, THEN #
+    # LOAD ANY OTHER MODULES REQUIRED BY THE KERNEL HERE.                 #
+    #######################################################################
 
     declare loopback_device="127.0.0.1"
     declare port="8888"

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -235,20 +235,16 @@ to connect to the notebook from your laptop. Open a terminal on your laptop and 
     http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
     ```
 
-As the instructions suggest, you access the jupyter lab server in the compute node by the following [SSH jump command](/connect/ssh/#ssh-jumps).
+As the instructions suggest, you access the jupyter lab server in the compute node by the following SSH command.
+
 ```shell
 ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
 ```
 
-??? info "TL;DR: SSH jump"
-    The [SSH jump command](/connect/ssh/#ssh-jumps) command,
+The above command,
 
-    ```shell
-    ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
-    ```
-
-    - opens a connection to your allocated cluster node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
-    - exports the port to the jupyter server in the local machine (`-L 8888:127.0.0.1:8888`).
+- opens a connection to your allocated cluster compute node jumping through the login node (`-J gkafanas@access-aion.uni.lu:8022 gkafanas@172.21.12.29`), and
+- forwards the port of the Jupyter server running in the compute node to your local machine (`-L 8888:127.0.0.1:8888`).
 
 Then, open the connection to the browser in your local machine by following the given link:
 ```

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -166,10 +166,10 @@ Jupyter notebooks must be started as [slurm jobs](/jobs/submit). The following s
     echo "# Connection instructions" > "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "To access the jupyter notebook execute on your personal machine:" >> "${connection_instructions}"
-    echo "ssh -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:${loopback_device}:${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
+    echo "ssh -N -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:${loopback_device}:${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "To access the jupyter notebook if you have setup a special key (e.g ulhpc_id_ed25519) to connect to cluster nodes execute on your personal machine:" >> "${connection_instructions}"
-    echo "ssh -i ~/.ssh/hpc_id_ed25519 -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:${loopback_device}:${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
+    echo "ssh -i ~/.ssh/hpc_id_ed25519 -N -J ${USER}@access-${ULHPC_CLUSTER}.uni.lu:8022 -L ${port}:${loopback_device}:${port} ${USER}@$(hostname -i)" >> "${connection_instructions}"
     echo "" >> "${connection_instructions}"
     echo "Then navigate to:" >> "${connection_instructions}"
 
@@ -226,10 +226,10 @@ to connect to the notebook from your laptop. Open a terminal on your laptop and 
     # Connection instructions
     
     To access the jupyter notebook execute on your personal machine:
-    ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
+    ssh -N -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
     
     To access the jupyter notebook if you have setup a special key (e.g ulhpc_id_ed25519) to connect to cluster nodes execute on your personal machine:
-    ssh -i ~/.ssh/ulhpc_id_ed25519 -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
+    ssh -i ~/.ssh/ulhpc_id_ed25519 -N -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
     
     Then navigate to:
     http://127.0.0.1:8888/?token=b7cf9d71d5c89627250e9a73d4f28cb649cd3d9ff662e7e2
@@ -238,7 +238,7 @@ to connect to the notebook from your laptop. Open a terminal on your laptop and 
 As the instructions suggest, you access the jupyter lab server in the compute node by the following SSH command.
 
 ```shell
-ssh -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
+ssh -N -J gkafanas@access-aion.uni.lu:8022 -L 8888:127.0.0.1:8888 gkafanas@172.21.12.29
 ```
 
 The above command,

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -19,7 +19,9 @@ We strongly recommend using the Jupyter application provided through [modules](/
 
 [Notebooks](https://docs.jupyter.org/en/latest/#what-is-a-notebook) are documents that contain computer code, data, and rich text elements such as normal test, graphical equations, links, figures, and widgets. The main advantage of Notebooks is that the concentrate human-readable analysis, descriptions, and results, together with executable versions of code data in a single document. As a result, notebooks are particularly popular for exploratory data analysis, where they allow the interactive development of reproducible data analytic pipelines. Notebooks can be shared or converted into static HTML documents, and they are thus a powerful teaching tool too.
 
-Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute the code of the notebook. You can host kernels on isolated Python environments or on the environment of the notebook. Whenever possible use the Python [module](/environment/modules/) to create your environment. Modules have been configured for optimal performance in our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
+### Kernels
+
+Notebooks are associated with [kernels](https://jupyter-client.readthedocs.io/en/stable/kernels.html), processes that actually execute the code of the notebook. You can host kernels on isolated Python environments or on the environment of the notebook. Whenever possible use the Python [module](/environment/modules/) to create your Python environments. Modules have been configured for optimal performance in our systems. If your application requires a different version of Python you can always install one with [Conda](/environment/conda/) or other tools.
 
 To create a Python environment for your kernel, start by loading the Python module and then create the environment. 
 
@@ -28,7 +30,7 @@ module load lang/Python
 python -m venv ${HOME}/environments/notebook_venv
 ```
 
-Install the packages that you require in your environment, and then install the `ipykernel` package.
+Install the packages that you require in your environment, and then install the IPython Kernel for Jupyter (`ipykernel`) package.
 
 ```shell
 module load lang/Python
@@ -37,7 +39,9 @@ pip install ipykernel
 deactivate
 ```
 
-You can then export a kernel for your environment that Jupyter applications can use to create notebooks for the environment. Jupyter applications provide a default environment with a kernel and also search some default locations for additional kernels. The user default location is selected with the `--user` option of `ipykernel` and is located in:
+The [IPython Kernel for Jupyter (`ipykernel`)](https://ipython.readthedocs.io/en/stable/index.html) provides Jupyter kernels that work with IPython, a toolkit for using Python interactively.
+
+You can then [install a kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html) for your environment; the kernel is used by Jupyter applications to create notebooks for the environment. Jupyter applications provide a default environment with a kernel and also search some default locations for additional kernels. The user default location is selected with the `--user` option of `ipykernel` and is located in:
 
 ```
 ${HOME}/.local/share/jupyter/kernels
@@ -327,32 +331,49 @@ You can also set a password when launching the jupyter lab as detailed in the [J
 
 ## Install Jupyter
 
-While JupyterLab runs code in Jupyter notebooks for many programming languages, Python is a requirement (Python 3.3 or greater, or Python 2.7) for installing the JupyterLab. New users may wish to install JupyterLab in a Conda environment. Hereafter, the `pip` package manager will be used to install JupyterLab.
-
-We strongly recommend to use the Python module provided by the ULHPC and installing `jupyter` inside a Python virtual environment after upgrading `pip`.
+In case you need some features of JupyterLab that are not available in the versions of JupyterLab provided by modules in our systems, you can install JupyterLab in a Python environment.
 
 ```shell
-$ si
-$ module load lang/Python #Loading default Python
-$ python -m venv ${HOME}/environments/jupyter_env
-$ source ${HOME}/environments/jupyter_env/bin/activate
-$ python -m pip install --upgrade pip
-$ python -m pip install jupyterlab
+module load lang/Python #Loading default Python
+python -m venv ${HOME}/environments/jupyter_venv
+source ${HOME}/environments/jupyter_venv/bin/activate
+pip install jupyterlab
 ```
 
-Once JupyterLab is installed along with , you can start to configure your installation setting the environment variables corresponding to your needs.
+??? info "Debugging installation issues"
 
-JupyterLab is now installed and ready.
+    If the installation of JupyterLab fails, try updating the version of `pip` in your environment,
+
+    ```shell
+    source ${HOME}/environments/jupyter_venv/bin/activate
+    python -m pip install --upgrade pip
+    ```
+
+    and try installing JupyterLab again.
+
+After installing your required version of JupyterLab, you can install your packages and [`ipykernel`](#kernels)
+
+- either in a separate Python environment, or
+- at the same python environment where JupyterLab is installed.
+
+??? info "Using a separate Python environment"
+
+    To use a separate Python environment [create a notebook](#notebook) and export its kernel so that the JupyterLab installed in your custom environment can  locate it. Remember, you only need to load the environment with JupyterLab, to launch JupyterLab, not the environment of the kernel.
+
+??? info "Using the Python environment of JupyterLab"
+
+    Every environment with JupyterLab already contains `ipykernel` to provide a default notebook. You can install all your packages directly in the `jupyter_venv` and use the default kernel. Note that in this manner you can only support one environment, and the packages you install in that environment must be compatible with the packages require by JupyterLab.
 
 ??? info "Installing the classic Notebook"
-    JupyterLab (`jupyterlab`) is a new package which automates many task that where performed manually in the traditional Jupyter package (`jupyter`). If you prefer to install the classic notebook, you also need to install the [IPython](https://ipython.readthedocs.io/en/stable/index.html) manually as well, replacing
+    If you prefer to install the classic notebook, you also need to install the [`ipykernel`](#kernels) manually. So, replace
     ```bash
-    python -m pip install jupyterlab
+    pip install jupyterlab
     ```
-    with:
+    with
     ```bash
-    python -m pip install jupyter ipykernel
+    pip install jupyter ipykernel
     ```
+    in the creation of the `jupyter_env` Python environment.
 
 ### Providing access to kernels of other environments
 

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -346,10 +346,34 @@ Jupyter generates various files during runtime, and reads configuration files fr
 
 ### Password protected access
 
-You can also set a password when launching the jupyter lab as detailed in the [Jupyter official documentation](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html). In that case, simply direct you browser to the URL `http://127.0.0.1:8888/` and provide your password. You can see bellow an example of the login page.
+You can also set a password when launching the Jupyter lab. To setup your password, open an interactive session and load the `tools/JupyterLab` [module](/environment/modules). Then execute the following command.
+
+```
+$ jupyter lab password
+Enter password:
+Verify password:
+[JupyterPasswordApp] Wrote hashed password to /mnt/aiongpfs/users/gkafanas/.jupyter/jupyter_server_config.json
+```
+
+To login to a password protected [session](#starting-a-jupyterlab-session), navigate direct you browser to the URL [`http://127.0.0.1:8888/`](http://127.0.0.1:8888/) and provide your password. You may have to logout to clear the page cache if you have logged in previously with a token.
+
+!!! info
+    You may have to logout to clear the page cache if you have logged in previously with a token.
 
 ??? example "Typical content of a password protected login page"
     ![](./images/jupyter_login.png)
+
+??? info "Setting up passwords for Jupyter Notebooks"
+    You can setup password protected logins in Jupyter notebooks similarly. Load the `tools/JupyterNotebook` [module](/environment/modules) and execute the following command.
+
+    ```
+    $ jupyter notebook password
+    Enter password:
+    Verify password:
+    [JupyterPasswordApp] Wrote hashed password to /mnt/aiongpfs/users/gkafanas/.jupyter/jupyter_server_config.json
+    ```
+
+    To login to a [running notebook](#starting-a-jupyterlab-session), navigate to [`http://127.0.0.1:8888/`](http://127.0.0.1:8888/) and enter your password. You may have to logout to clear the page cache if you have logged in previously with a token.
 
 
 ## Install Jupyter

--- a/docs/services/jupyter.md
+++ b/docs/services/jupyter.md
@@ -316,10 +316,16 @@ If you encounter any issues, have a look in the debug output in `Jupyter_<job id
 
 Jupyter generates various files during runtime, and reads configuration files from various locations. You can control these paths using [environment variables](https://docs.jupyter.org/en/latest/use/jupyter-directories.html). For instance, you may set the `JUPYTER_RUNTIME_DIR` to point somewhere in the [`/tmp` directory](https://hpc-docs.uni.lu/filesystems/#intended-usage-of-file-systems) for better performance.
 
-- [`JUPYTER_CONFIG_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_CONFIG_DIR): Set the directory for Jupyter config files; default is `${HOME}/.jupyter`.
-- [`JUPYTER_PATH`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_PATH): Extra directories to search for installable data files, such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter) and [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/); should contain a series of directories, separated by `os.pathsep` (`;` on Windows and `:` on Unix); directories given in `JUPYTER_PATH` are searched before other locations.
-- [`JUPYTER_DATA_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_DATA_DIR): Set the user data directory which contains files such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter), [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/), or [voila templates](https://voila.readthedocs.io/en/stable/index.html); default is `${HOME}/.local/share/jupyter/` (respects `${XDG_DATA_HOME}`).
-- [`JUPYTER_RUNTIME_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_RUNTIME_DIR): Set the location where Jupyter stores runtime files, such as connection files, which are only useful for the lifetime of a particular process; default is `${JUPYTER_DATA_DIR}/runtime`.
+#### JupyterLab
+
+- [`JUPYTER_CONFIG_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_CONFIG_DIR): set the directory for Jupyter config files; default is `${HOME}/.jupyter`.
+- [`JUPYTER_PATH`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_PATH): extra directories to search for installable data files, such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter) and [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/); should contain a series of directories, separated by `os.pathsep` (`;` on Windows and `:` on Unix); directories given in `JUPYTER_PATH` are searched before other locations.
+- [`JUPYTER_DATA_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_DATA_DIR): set the user data directory which contains files such as [kernelspecs](https://jupyter-client.readthedocs.io/en/stable/kernels.html#making-kernels-for-jupyter), [notebook extensions](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/), or [voila templates](https://voila.readthedocs.io/en/stable/index.html); default is `${HOME}/.local/share/jupyter/` (respects `${XDG_DATA_HOME}`).
+- [`JUPYTER_RUNTIME_DIR`](https://docs.jupyter.org/en/latest/use/jupyter-directories.html#envvar-JUPYTER_RUNTIME_DIR): set the location where Jupyter stores runtime files, such as connection files, which are only useful for the lifetime of a particular process; default is `${JUPYTER_DATA_DIR}/runtime`.
+
+#### IPython Kernel for Jupyter (`ipykernel`)
+
+- [`IPYTHONDIR`](https://ipython.readthedocs.io/en/stable/config/intro.html#envvar-IPYTHONDIR): path to a directory where [IPython](#kernels) will store user data; IPython will create it if it does not exist.
 
 ### Password protected access
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,7 @@ nav:
     #   - Parsl: 'jobs/workflow/parsl.md'
     #   - Snakemake: 'jobs/workflow/snakemake.md'
     #   - Spark Cluster: 'bigdata/spark.md'
-    - Jupyter Notebook: 'services/jupyter.md'
+    - Jupyter: 'services/jupyter.md'
     # - Checkpoint/Restart: 'jobs/checkpoint-restart.md'
   ###########
   - Software:


### PR DESCRIPTION
We provided Jupyter applications as modules. This PR updated the documentation to reflect that.

More crucially, this PR updates the documentation about proxy jump and SSH agent forwarding. ProxyJump eliminates the need for SSH agent forwarding, whenever jumping through host on connection time. This was not clear in the old documentation and mentions to SSH agent forwarding polluted various location in the Jupyter and SSH sections that are updated in this PR.