### PR TITLE
Update numpy and pandas to 2.3.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,8 @@ mkdocs-material==9.6.14
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.3.0
 nltk==3.5
-numpy==1.21.6
-pandas==1.3.5
+numpy==2.3.1
+pandas==2.3.1
 pep562==1.0
 Pygments==2.16
 pymdown-extensions==10.2


### PR DESCRIPTION
The newer version are required to build with more recent versions of Python, such as 3.11.