### PR TITLE
BREAKING BUGFIX: Enable alternate tabbed extension style

### DIFF
--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -1,0 +1,106 @@
+## Running jobs with GNU parallel
+
+The Slurm scheduler performs 2 jobs,
+
+- allocate resources for a job (allocation),
+- lunches the job steps.
+
+The job steps are the actual processes launched within a job which consume the job resources. Resources can be entities like nodes, CPU cores, GPUs, and memory allocated for the job. The job steps can execute in serial or parallel given that enough resources are available.
+
+The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180sec depending on the Slurm configuration. The resource allocation loop is quite time consuming as the scheduler is configured to perform operations such as back-filling. If a lot of small jobs are in the queue, they tend to trigger expensive operations such as back-filling, and can delay the scheduling loop past its usual period. The end result is a scheduler with sluggish response.
+
+To avoid multiple small jobs, we can schedule multiple jobs in a single allocation.
+
+```bash
+#!/bin/bash --login
+#SBATCH --job-name=single_process
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=16
+#SBATCH --time=02:00:00
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+#SBATCH --exclusive
+#SBATCH --mem=0
+
+declare stress_test_duration=160
+
+parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 stress --cpu 16 --timeout "${stress_test_duration}" ::: {0..255}
+```
+
+The scheduler is much more efficient in lunching job steps within a job, as the resources have been allocated and there is no need to interact with the resource allocation loop. Job steps are lunched in blocking calls within a job whenever a `srun` command is executes in the job.
+
+However, even there are limit even in the number of job steps per job, as the scheduler needs to keep some information for each job step and multiple small jobs steps encumber the scheduler database. To reduce the number of job steps, we can group smaller jobs into groups of jobs lanced with parallel within a job step.
+
+There are 2 options when lunching multiple scripts in a single step, we can launch them in an external script or within functions. When using an external script, call the external script from your main script
+
+```bash
+#!/bin/bash --login
+#SBATCH --job-name=multi_process
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=16
+#SBATCH --time=02:00:00
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+#SBATCH --exclusive
+#SBATCH --mem=0
+
+declare stress_test_duration=5
+declare operations_per_step=256
+
+parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 run_job_step "${operations_per_step}" "${stress_test_duration}" ::: {0..255}
+```
+
+and ensure that the external script is accessible, for instance placed in the same directory:
+
+```bash
+#!/bin/bash --login
+# Contents of `run_job_step`
+
+declare total_operations="${1}"
+declare test_duration="${2}"
+declare final_operation=$((${total_operations}-1))
+
+parallel --max-procs 4 --max-args 0 stress --cpu 4 --timeout "${test_duration}" ::: $(seq 0 "${final_operation}")
+```
+
+When running the job in a function, make sure that the function is exported to the environment of `srun`:
+
+```bash
+#!/bin/bash --login
+#SBATCH --job-name=function_multi_process
+#SBATCH --partition=batch
+#SBATCH --qos=normal
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=16
+#SBATCH --time=02:00:00
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+#SBATCH --exclusive
+#SBATCH --mem=0
+
+declare stress_test_duration=5
+declare operations_per_step=256
+
+run_step() {
+  local total_operations="${1}"
+  local test_duration="${2}"
+  local final_operation=$((${total_operations}-1))
+
+  parallel --max-procs 4 --max-args 0 stress --cpu 4 --timeout "${test_duration}" ::: $(seq 0 "${final_operation}")
+}
+
+export -f run_step
+
+parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 bash -c "\"run_step ${operations_per_step} ${stress_test_duration}\"" ::: {0..255}
+```
+
+_Resources_
+
+- [luncher_script_examples.zip](https://github.com/user-attachments/files/21215923/luncher_script_examples.zip)

--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -2,14 +2,17 @@
 
 The Slurm scheduler performs 2 jobs,
 
-- allocate resources for a job (allocation),
-- lunches the job steps.
+- allocates resources for a job (allocation),
+- launches the job steps.
+
+
 
 The job steps are the actual processes launched within a job which consume the job resources. Resources can be entities like nodes, CPU cores, GPUs, and memory allocated for the job. The job steps can execute in serial or parallel given that enough resources are available.
 
 The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180sec depending on the Slurm configuration. The resource allocation loop is quite time consuming as the scheduler is configured to perform operations such as back-filling. If a lot of small jobs are in the queue, they tend to trigger expensive operations such as back-filling, and can delay the scheduling loop past its usual period. The end result is a scheduler with sluggish response.
 
 To avoid multiple small jobs, we can schedule multiple jobs in a single allocation.
+
 
 ```bash
 #!/bin/bash --login
@@ -101,6 +104,108 @@ export -f run_step
 parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 bash -c "\"run_step ${operations_per_step} ${stress_test_duration}\"" ::: {0..255}
 ```
 
+
+## Launching concurrent programs in one allocation
+
+Many real‑world pipelines need to run several different executables inside a single Slurm allocation. The simplest way to orchestrate them is to provide a space‑ or tab‑delimited command table:
+
+```bash
+#!/bin/bash --login
+#SBATCH --job-name=many_programs
+# ... Slurm directives ...
+
+cat > cmdlist.txt <<'EOF'
+fastqc   sample1.fastq.gz
+samtools sort sample1.bam -o sample1.sorted.bam
+python   train_model.py --epochs 10
+EOF
+
+parallel --colsep ' +' --max-procs "${SLURM_NTASKS}" \
+        srun --nodes=1 --ntasks=1 {1} {2..}  \
+        :::: cmdlist.txt
+```
+
+* `{1}` is the program; `{2..}` expands to the remaining columns (its arguments).
+* `--colsep ' +'` treats runs of spaces or tabs as column separators.
+
+
+
+## Collecting Logs and Monitoring Progress
+
+```bash
+parallel --joblog run.log \
+         --results results/{#}/ \
+         --bar --eta \
+         srun ... ::: ${TASKS}
+```
+
+* **`run.log`** — TSV with start/finish, runtime, exit status.
+* **`results/{#}`** — one directory per task; stdout/stderr captured automatically.
+* **`--bar`** — live progress bar; **`--eta`** — estimated completion time.
+
+Tail the bar in real time:
+
+```bash
+tail -f --pid=${PARALLEL_PID} parallel_bar.log
+```
+
+
+## Error Handling and Automatic Retries
+
+Enable bounded retries for flaky tasks:
+
+```bash
+parallel --retries 3 --halt now,fail=1 \
+         srun ... ::: ${TASKS}
+```
+
+* `--retries 3` — attempt each job up to 3 times.
+* `--halt now,fail=1` — abort the whole allocation if any task keeps failing.
+
+For *checkpointable* binaries, pair Parallel’s resume file with `--resume`:
+
+```bash
+parallel --joblog run.log --resume-failed ...
+```
+
+
+## Performance Tuning Tips
+
+| Symptom                     | Lever                | Example                           |
+| --------------------------- | -------------------- | --------------------------------- |
+| I/O saturation on shared FS | `--compress`         | pipe‑compress large stdout chunks |
+| Many tiny files             | `--results /scratch` | stage results to local SSD first  |
+| CPU under‑utilisation       | `--block 10M`        | batch stdin in 10 MB chunks       |
+| SSH startup cost            | `--sshloginfile`     | reuse control master via `-M`     |
+
+Benchmark one tweak at a time; use `sar`/`iostat` on compute nodes to confirm bottlenecks.
+
+
+
+## Comparing GNU Parallel and Slurm Job Arrays
+
+GNU Parallel and Slurm job arrays both launch many similar tasks, but they solve *different* bottlenecks.
+
+| Use Case                                           | Prefer GNU Parallel                               | Prefer Slurm Array                          |
+| -------------------------------------------------- | ------------------------------------------------- | ------------------------------------------- |
+| **Interactive/rapid turn‑around** (e.g. dev nodes) | ✔ Parallel runs immediately inside one allocation | ✖ Array needs scheduler cycle for each task |
+| **Thousands of ultra‑short jobs**                  | ✔ Drastically reduces queue chatter               | ✖ Creates scheduling overhead               |
+| **Need individual Slurm accounting per task**      | ✖ All tasks share one Slurm step                  | ✔ Each array index has its own record       |
+| **Mix heterogeneous commands**                     | ✔ Parallel can vary executable per line           | ✖ Arrays assume one script                  |
+| **Checkpoint/re‑queue tasks**                      | ✖ Must script custom resume                       | ✔ Native `--array` + `--requeue`            |
+
+A quick rule‑of‑thumb:
+
+> *If the run time of the task is **less than the scheduler cycle** (≈30‑180 s), package the tasks with GNU Parallel.*
+
+---
+
+
+
+
+
+
 _Resources_
 
 - [luncher_script_examples.zip](https://github.com/user-attachments/files/21215923/luncher_script_examples.zip)
+- 

--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -5,14 +5,11 @@ The Slurm scheduler performs 2 jobs,
 - allocates resources for a job (allocation),
 - launches the job steps.
 
-
-
 The job steps are the actual processes launched within a job which consume the job resources. Resources can be entities like nodes, CPU cores, GPUs, and memory allocated for the job. The job steps can execute in serial or parallel given that enough resources are available.
 
 The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180sec depending on the Slurm configuration. The resource allocation loop is quite time consuming as the scheduler is configured to perform operations such as back-filling. If a lot of small jobs are in the queue, they tend to trigger expensive operations such as back-filling, and can delay the scheduling loop past its usual period. The end result is a scheduler with sluggish response.
 
 To avoid multiple small jobs, we can schedule multiple jobs in a single allocation.
-
 
 ```bash
 #!/bin/bash --login

--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -1,19 +1,34 @@
-## Running jobs with GNU parallel
+[GNU parallel](https://www.gnu.org/software/parallel/) allows the execution of multiple small jobs in an HPC cluster without overloading the [cluster scheduler](/slurm/). The Slurm scheduler performs 2 jobs,
 
-The Slurm scheduler performs 2 jobs,
+- allocates resources for a job,
+- launches the [job steps](/jobs/steps/).
 
-- allocates resources for a job (allocation),
-- launches the job steps.
 
-The job steps are the actual processes launched within a job which consume the job resources. Resources can be entities like nodes, CPU cores, GPUs, and memory allocated for the job. The job steps can execute in serial or parallel given that enough resources are available.
+<!--
 
-The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180sec depending on the Slurm configuration. The resource allocation loop is quite time consuming as the scheduler is configured to perform operations such as back-filling. If a lot of small jobs are in the queue, they tend to trigger expensive operations such as back-filling, and can delay the scheduling loop past its usual period. The end result is a scheduler with sluggish response.
+Job steps launch processes within a job which consume the job resources.
 
-To avoid multiple small jobs, we can schedule multiple jobs in a single allocation.
+-->
+
+The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180s, depending on the Slurm configuration. If a lot of small jobs are in the queue, then expensive operations, such as back-filling, are triggered during the allocation loop. As a result, the scheduling loop can delay past its period, causing the scheduler to appear slow and unresponsive.
+
+To avoid multiple small jobs, schedule multiple job steps in a single allocation with GNU parallel.
+
+## Running HPC jobs with GNU parallel
+
+[GNU parallel](https://www.gnu.org/software/parallel/) (command `parallel`)is a shell tool for executing jobs in parallel using one or more computers. A job can be a single command or a small script that has to be run for each of the lines in the input.
+
+- The jobs are forked from the main job when the `parallel` command executes.
+- The parallel command blocks until all forked processes exit.
+- You can limit the number of jobs that run in parallel; `parallel` implements a form of process pull, where a limited number of processes running in parallel executes the jobs.
+
+### Running a single GNU parallel job per job step
+
+The scheduler is much more efficient in lunching job steps within a job, where resources have been allocated and there is no need to interact with the resource allocation loop. Job steps are lunched within a job with call to the blocking `srun` command, so the executable needs to be launched with the `srun` command within GNU parallel.
 
 ```bash
 #!/bin/bash --login
-#SBATCH --job-name=single_process
+#SBATCH --job-name=single_job_per_step
 #SBATCH --partition=batch
 #SBATCH --qos=normal
 #SBATCH --nodes=4
@@ -22,85 +37,162 @@ To avoid multiple small jobs, we can schedule multiple jobs in a single allocati
 #SBATCH --time=02:00:00
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
-#SBATCH --exclusive
-#SBATCH --mem=0
 
 declare stress_test_duration=160
 
-parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 stress --cpu 16 --timeout "${stress_test_duration}" ::: {0..255}
+parallel \
+  --max-procs "${SLURM_NTASKS}" \
+  --max-args 0 \
+  srun \
+    --nodes=1 \
+    --ntasks=1 \
+    stress-ng \
+      --cpu ${SLURM_CPUS_PER_TASK} \
+      --timeout "${stress_test_duration}" \
+      ::: {0..255}
 ```
 
-The scheduler is much more efficient in lunching job steps within a job, as the resources have been allocated and there is no need to interact with the resource allocation loop. Job steps are lunched in blocking calls within a job whenever a `srun` command is executes in the job.
+This example script launches a single job step per GNU parallel job. The executable `stress-ng` is a stress test program.
 
-However, even there are limit even in the number of job steps per job, as the scheduler needs to keep some information for each job step and multiple small jobs steps encumber the scheduler database. To reduce the number of job steps, we can group smaller jobs into groups of jobs lanced with parallel within a job step.
+- The number of GNU parallel jobs is limited to the number of tasks, `SLURM_NTASKS`, so that there is no overallocation of GNU parallel jobs. Note that if a jobs step is launched without sufficient resources, then the job step fails.
+- Each job step is consuming a single task (`--ntasks=1`) that has access to `SLURM_CPUS_PER_TASK` CPUs. The `stress-ng` program requires the explicit specification of the number of CPUs to use for the CPU benchmark with the `--cpu` flag.
 
-There are 2 options when lunching multiple scripts in a single step, we can launch them in an external script or within functions. When using an external script, call the external script from your main script
+??? info "Slurm environment variables (`SLURM_*`)"
+    Upon starting a job step, `srun` reads the options defined in a set of environment variables, most of the starting with the prefix `SLURM_`. The scheduler it self will set many of these variables with an allocation for a job is created. Some useful variables set and their corresponding allocation (`sbatch`/`salloc`) flags are the following.
 
-```bash
-#!/bin/bash --login
-#SBATCH --job-name=multi_process
-#SBATCH --partition=batch
-#SBATCH --qos=normal
-#SBATCH --nodes=4
-#SBATCH --ntasks-per-node=8
-#SBATCH --cpus-per-task=16
-#SBATCH --time=02:00:00
-#SBATCH --output=%x-%j.out
-#SBATCH --error=%x-%j.err
-#SBATCH --exclusive
-#SBATCH --mem=0
+    - `--nodes`: `SLURM_NNODES`
+    - `--ntasks`: `SLURM_NTASKS`
+    - `--ntasks-per-node`: `SLURM_NTASKS_PER_NODE`
+    - `--cpus-per-task`: `SLURM_CPUS_PER_TASK`
 
-declare stress_test_duration=5
-declare operations_per_step=256
+    Note that some environment variables are evaluated implicitly even if the corresponding option is not defined for the allocation. For instance in the example above we define `--nodes` and `--ntasks-per-node`, but not `--ntasks`, yet the `SLURM_NTASKS` is set to
 
-parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 run_job_step "${operations_per_step}" "${stress_test_duration}" ::: {0..255}
-```
+    ```
+    SLURM_NTASKS = SLURM_NNODES * SLURM_NTASKS_PER_NODE = 4 * 8 = 24
+    ```
 
-and ensure that the external script is accessible, for instance placed in the same directory:
+    and its value can be used in the submission script without defining `--nodes`.
 
-```bash
-#!/bin/bash --login
-# Contents of `run_job_step`
+### Running multiple GNU parallel jobs per job step
 
-declare total_operations="${1}"
-declare test_duration="${2}"
-declare final_operation=$((${total_operations}-1))
+If a jobs contains a massive amounts of very small job steps, it can be limited by the rate in which job steps can be launched. The scheduler stores keep some information for each job step in a database, and with multiple small steps launching in parallel the throughput limits of the database system can exceeded affecting every job in the cluster.
 
-parallel --max-procs 4 --max-args 0 stress --cpu 4 --timeout "${test_duration}" ::: $(seq 0 "${final_operation}")
-```
+In these extreme cases, GNU parallel can limit the number of job steps by grouping multiple GNU parallel jobs in a single job step. There are 2 options when lunching multiple GNU parallel jobs in a single jobs step, the GNU parallel jobs of the step can be launched in a script or in a function.
 
-When running the job in a function, make sure that the function is exported to the environment of `srun`:
+=== "GNU parallel jobs in a script"
+    !!! example "Submission script"
+        ```bash
+        #!/bin/bash --login
+        #SBATCH --job-name=multi_job_per_step_script
+        #SBATCH --partition=batch
+        #SBATCH --qos=normal
+        #SBATCH --nodes=4
+        #SBATCH --ntasks-per-node=8
+        #SBATCH --cpus-per-task=16
+        #SBATCH --time=02:00:00
+        #SBATCH --output=%x-%j.out
+        #SBATCH --error=%x-%j.err
 
-```bash
-#!/bin/bash --login
-#SBATCH --job-name=function_multi_process
-#SBATCH --partition=batch
-#SBATCH --qos=normal
-#SBATCH --nodes=4
-#SBATCH --ntasks-per-node=8
-#SBATCH --cpus-per-task=16
-#SBATCH --time=02:00:00
-#SBATCH --output=%x-%j.out
-#SBATCH --error=%x-%j.err
-#SBATCH --exclusive
-#SBATCH --mem=0
+        declare stress_test_duration=5
+        declare steps=256
+        declare substeps_per_step=1024
+        declare cpus_per_substep=4
 
-declare stress_test_duration=5
-declare operations_per_step=256
+        declare final_step=$(( ${steps} - 1 ))
 
-run_step() {
-  local total_operations="${1}"
-  local test_duration="${2}"
-  local final_operation=$((${total_operations}-1))
+        parallel \
+          --max-procs "${SLURM_NTASKS}" \
+          --max-args 0 \
+          srun \
+            --nodes=1 \
+            --ntasks=1 \
+            run_job_step \
+              "${substeps_per_step}" \
+              "${cpus_per_substep}" \
+              "${SLURM_CPUS_PER_TASK}" \
+              "${stress_test_duration}" \
+              ::: $(seq 0 ${final_step})
+        ```
 
-  parallel --max-procs 4 --max-args 0 stress --cpu 4 --timeout "${test_duration}" ::: $(seq 0 "${final_operation}")
-}
+    Ensure that the external script `run_job_step` is accessible from submission script, for instance, place both scripts in the same directory.
 
-export -f run_step
 
-parallel --max-procs "${SLURM_NTASKS}" --max-args 0 srun --nodes=1 --ntasks=1 bash -c "\"run_step ${operations_per_step} ${stress_test_duration}\"" ::: {0..255}
-```
+    !!! example "External job step execution script `run_job_step`"
+        ```bash
+        #!/bin/bash --login
 
+        declare substeps="${1}"
+        declare cpus_per_substep="${2}"
+        declare cpus_per_step="${3}"
+        declare test_duration="${4}"
+
+        declare final_substep=$(( ${substeps} - 1 ))
+        declare max_parallel_substeps=$(( ${cpus_per_step} / ${cpus_per_substep} ))
+
+        parallel \
+          --max-procs "${max_parallel_substeps}" \
+          --max-args 0 \
+          stress \
+            --cpu "${cpus_per_substep}" \
+            --timeout "${test_duration}" \
+            ::: $(seq 0 "${final_substep}")
+        ```
+
+=== "GNU parallel jobs in a function"
+    !!! example "Submission script"
+        ```bash
+        #!/bin/bash --login
+        #SBATCH --job-name=multi_job_per_step_function
+        #SBATCH --partition=batch
+        #SBATCH --qos=normal
+        #SBATCH --nodes=4
+        #SBATCH --ntasks-per-node=8
+        #SBATCH --cpus-per-task=16
+        #SBATCH --time=02:00:00
+        #SBATCH --output=%x-%j.out
+        #SBATCH --error=%x-%j.err
+
+        declare stress_test_duration=5
+        declare steps=256
+        declare substeps_per_step=1024
+        declare cpus_per_substep=4
+
+        run_step() {
+          local total_substeps="${1}"
+          local test_duration="${2}"
+
+          local final_substep=$(( ${total_substeps} - 1 ))
+          local max_parallel_substeps=$(( ${SLURM_CPUS_PER_TASK} / ${cpus_per_substep} ))
+
+          parallel \
+            --max-procs "${max_parallel_substeps}" \
+            --max-args 0 \
+            stress-ng \
+              --cpu "${cpus_per_substep}" \
+              --timeout "${test_duration}" \
+              ::: $(seq 0 "${final_substep}")
+        }
+
+        export -f run_step
+
+        declare final_step=$(( ${steps} - 1 ))
+
+        parallel \
+          --max-procs "${SLURM_NTASKS}" \
+          --max-args 0 \
+          srun \
+            --nodes=1 \
+            --ntasks=1 \
+            bash \
+              -c "\"run_step ${substeps_per_step} ${stress_test_duration}\"" \
+              ::: $(seq 0 ${final_step})
+        ```
+
+    When running the GNU parallel job steps in a function, make sure that the function is exported to the environment of `srun` with the `export -f` bash builtin command.
+
+---
+
+<!--
 
 ## Launch concurrent Programs in One Allocation
 
@@ -186,7 +278,7 @@ parallel --joblog run.log --resume-failed ...
 
 ---
 
-> **Tip**: If your tasks are shorter than the scheduler wait time (around **30 to 180 seconds**), it's better to use **GNU Parallel**. Otherwise, use **Slurm Job Arrays**.
+**Tip**: If your tasks are shorter than the scheduler wait time (around **30 to 180 seconds**), it's better to use **GNU Parallel**. Otherwise, use **Slurm Job Arrays**.
 
 
 ---
@@ -199,3 +291,5 @@ parallel --joblog run.log --resume-failed ...
 _Resources_
 
 - [luncher_script_examples.zip](https://github.com/user-attachments/files/21215923/luncher_script_examples.zip)
+
+-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -419,7 +419,8 @@ markdown_extensions:
       social_url_shorthand: true
   - pymdownx.snippets:
       base_path: snippets
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.smartsymbols
   # code blocks with syntax highlighting, graphs
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
     - Long Jobs: 'jobs/long.md'
     - Best-effort Jobs: 'jobs/best-effort.md'
     - Launcher Scripts Examples: 'slurm/launchers.md'
+    - GNU parallel: 'jobs/gnu-parallel.md'
     # - Affinity: 'jobs/affinity.md'
     # - (Multi-)GPU Jobs: 'jobs/gpu.md'
     # - Memory Management: 'jobs/memory.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,30 +117,30 @@ nav:
   - Software:
     ### BEGIN GENERATED CONTENT
     - Supported Software List:
-        - Overview: 'software/swsets/index.md'
-        - Full List (alphabetical order): 'software/swsets/all_softwares.md'
-        - Biology: 'software/swsets/bio.md'
-        - CFD/Finite element modelling: 'software/swsets/cae.md'
-        - Chemistry: 'software/swsets/chem.md'
-        - Compilers: 'software/swsets/compiler.md'
-        - Data processing: 'software/swsets/data.md'
-        - Debugging: 'software/swsets/debugger.md'
-        - Development: 'software/swsets/devel.md'
-        # - Weather modelling: 'software/swsets/geo.md'
-        - Programming Languages: 'software/swsets/lang.md'
-        - Libraries: 'software/swsets/lib.md'
-        - Mathematics: 'software/swsets/math.md'
-        - MPI: 'software/swsets/mpi.md'
-        - Numerical libraries: 'software/swsets/numlib.md'
-        - Performance measurements: 'software/swsets/perf.md'
-        - Physics: 'software/swsets/phys.md'
-        - System-level software: 'software/swsets/system.md'
-        - Toolchains (software stacks): 'software/swsets/toolchain.md'
-        - Utilities: 'software/swsets/tools.md'
-        - Visualisation: 'software/swsets/vis.md'
+      - Overview: 'software/swsets/index.md'
+      - Full List (alphabetical order): 'software/swsets/all_softwares.md'
+      - Biology: 'software/swsets/bio.md'
+      - CFD/Finite element modelling: 'software/swsets/cae.md'
+      - Chemistry: 'software/swsets/chem.md'
+      - Compilers: 'software/swsets/compiler.md'
+      - Data processing: 'software/swsets/data.md'
+      - Debugging: 'software/swsets/debugger.md'
+      - Development: 'software/swsets/devel.md'
+      # - Weather modelling: 'software/swsets/geo.md'
+      - Programming Languages: 'software/swsets/lang.md'
+      - Libraries: 'software/swsets/lib.md'
+      - Mathematics: 'software/swsets/math.md'
+      - MPI: 'software/swsets/mpi.md'
+      - Numerical libraries: 'software/swsets/numlib.md'
+      - Performance measurements: 'software/swsets/perf.md'
+      - Physics: 'software/swsets/phys.md'
+      - System-level software: 'software/swsets/system.md'
+      - Toolchains (software stacks): 'software/swsets/toolchain.md'
+      - Utilities: 'software/swsets/tools.md'
+      - Visualisation: 'software/swsets/vis.md'
     - Software Sets:
-        - 2019b: 'software/swsets/2019b.md'
-        - 2020a: 'software/swsets/2020b.md'
+       - 2019b: 'software/swsets/2019b.md'
+       - 2020a: 'software/swsets/2020b.md'
     ### END GENERATED CONTENT
     # - Software Set Versioning:     'software/swsets.md'
     - Compiling/building your own software: 'software/build.md'
@@ -150,34 +150,34 @@ nav:
     # - BigData Analytics:           'software/bigdata/index.md'
     # - Bioinformatics/Life Science: 'software/bio/index.md'
     - Computer Aided Eng. (CAE):
-        - FEniCS : 'software/cae/fenics.md'
-        - ANSYS : 'software/cae/ansys.md'
-        - OpenFOAM : 'software/cae/openfoam.md'
-        - Abaqus : 'software/cae/abaqus.md'
-        - FDS : 'software/cae/fds.md'
-        - Meshing-Tools : 'software/cae/meshing-tools.md'
+      - FEniCS : 'software/cae/fenics.md'
+      - ANSYS : 'software/cae/ansys.md'
+      - OpenFOAM : 'software/cae/openfoam.md'
+      - Abaqus : 'software/cae/abaqus.md'
+      - FDS : 'software/cae/fds.md'
+      - Meshing-Tools : 'software/cae/meshing-tools.md'
     - Physics:
-        - WRF: 'software/physics/wrf.md'
+      - WRF: 'software/physics/wrf.md'
     - Computational Chemistry:
-        - Electronics:
-            - ABINIT:              'software/computational-chemistry/electronics/abinit.md'
-            - ASE:                 'software/computational-chemistry/electronics/ase.md'
-            - MEEP:                'software/computational-chemistry/electronics/meep.md'
-            - Quantum Espresso:    'software/computational-chemistry/electronics/quantum-espresso.md'
-            - VASP:                'software/computational-chemistry/electronics/vasp.md'
-        - Molecular Dynamics:
-            - CP2K: 'software/computational-chemistry/molecular-dynamics/cp2k.md'
-            - GROMACS: 'software/computational-chemistry/molecular-dynamics/gromacs.md'
-            - NAMD: 'software/computational-chemistry/molecular-dynamics/namd.md'
-            - NWCHEM: 'software/computational-chemistry/molecular-dynamics/nwchem.md'
-            - Helping Libraries: 'software/computational-chemistry/molecular-dynamics/helping-libraries.md'
+      - Electronics:
+        - ABINIT:              'software/computational-chemistry/electronics/abinit.md'
+        - ASE:                 'software/computational-chemistry/electronics/ase.md'
+        - MEEP:                'software/computational-chemistry/electronics/meep.md'
+        - Quantum Espresso:    'software/computational-chemistry/electronics/quantum-espresso.md'
+        - VASP:                'software/computational-chemistry/electronics/vasp.md'
+      - Molecular Dynamics:
+        - CP2K: 'software/computational-chemistry/molecular-dynamics/cp2k.md'
+        - GROMACS: 'software/computational-chemistry/molecular-dynamics/gromacs.md'
+        - NAMD: 'software/computational-chemistry/molecular-dynamics/namd.md'
+        - NWCHEM: 'software/computational-chemistry/molecular-dynamics/nwchem.md'
+        - Helping Libraries: 'software/computational-chemistry/molecular-dynamics/helping-libraries.md'
     # - Deep and Machine Learning:   'software/ml/index.md'
     # - Earth Sciences:              'software/geo/index.md'
     - Mathematics & Statistics:
-          - MATLAB:    'software/maths/matlab.md'
-          - MATHEMATICA:    'software/maths/mathematica.md'
-          - Stata: 'software/maths/stata.md'
-          - Julia:    'software/maths/julia.md'
+      - MATLAB:    'software/maths/matlab.md'
+      - MATHEMATICA:    'software/maths/mathematica.md'
+      - Stata: 'software/maths/stata.md'
+      - Julia:    'software/maths/julia.md'
     - Optimizers:                  'software/optim/index.md'
     # - Performance/Debugging:       'development/performance-debugging-tools/index.md'
     # - Physics:                     'software/phys/index.md'
@@ -188,66 +188,66 @@ nav:
   ##############
   - Development:
     # - Toolchains and Compilers:
-    #     - Overview: 'development/toolchains/index.md'
-    #     - FOSS:     'development/toolchains/foss.md'
-    #     - Intel:    'development/toolchains/intel.md'
-    #     - LLVM:     'development/compilers/llvm.md'
-    #     - PGI:      'development/compilers/pgi.md'
+    #   - Overview: 'development/toolchains/index.md'
+    #   - FOSS:     'development/toolchains/foss.md'
+    #   - Intel:    'development/toolchains/intel.md'
+    #   - LLVM:     'development/compilers/llvm.md'
+    #   - PGI:      'development/compilers/pgi.md'
     # - Build Tools:
-    #     - Autoconf and Make: 'development/build-tools/autoconf-make.md'
-    #     - CMake:             'development/build-tools/cmake.md'
-    #     - EasyBuild:         'development/build-tools/easybuild.md'
-    #     - Spack:             'https://spack-tutorial.readthedocs.io/en/latest/'
+    #   - Autoconf and Make: 'development/build-tools/autoconf-make.md'
+    #   - CMake:             'development/build-tools/cmake.md'
+    #   - EasyBuild:         'development/build-tools/easybuild.md'
+    #   - Spack:             'https://spack-tutorial.readthedocs.io/en/latest/'
     # - Programming Models:
-    #     - Overview: 'development/programming-models/index.md'
-    #     - MPI Stack:
-    #       - About:   'development/programming-models/mpi/index.md'
-    #       - OpenMPI: 'development/programming-models/mpi/openmpi.md'
-    #     - OpenMP:  'development/programming-models/openmp/openmp.md'
-    #     - CUDA:    'development/programming-models/cuda.md'
-    #     - Kokkos : 'development/programming-models/kokkos.md'
-    #     - UPC :    'development/programming-models/upc.md'
+    #   - Overview: 'development/programming-models/index.md'
+    #   - MPI Stack:
+    #     - About:   'development/programming-models/mpi/index.md'
+    #     - OpenMPI: 'development/programming-models/mpi/openmpi.md'
+    #   - OpenMP:  'development/programming-models/openmp/openmp.md'
+    #   - CUDA:    'development/programming-models/cuda.md'
+    #   - Kokkos : 'development/programming-models/kokkos.md'
+    #   - UPC :    'development/programming-models/upc.md'
     # - Languages:
-    #     - Go:    'development/languages/go.md'
-    #     - Java:  'development/languages/java.md'
-    #     - Julia: 'development/languages/julia.md'
-    #     - Python:
-    #         - About:            'development/languages/python/index.md'
-    #         - Virtual Env.:     'development/languages/python/venv.md'
-    #         - Best Practices:   'development/languages/python/best-practices.md'
-    #         - Python on GPU:    'development/languages/python/python-on-gpu.md'
-    #         - Scaling Up:       'development/languages/python/scaling-up.md'
-    #         - Multiprocessing:  'development/languages/python/multiprocessing.md'
-    #         - mpi4py:           'development/languages/python/mpi4py.md'
-    #         - Notebook:         'development/languages/python/notebook.md'
-    #         - Python Profiling: 'development/languages/python/profiling.md'
-    #         - Python FAQ:       'development/languages/python/faq.md'
-    #     - R:    'development/languages/r.md'
-    #     - Ruby: 'development/languages/ruby.md'
-    #     - Rust: 'development/languages/rust.md'
+    #   - Go:    'development/languages/go.md'
+    #   - Java:  'development/languages/java.md'
+    #   - Julia: 'development/languages/julia.md'
+    #   - Python:
+    #     - About:            'development/languages/python/index.md'
+    #     - Virtual Env.:     'development/languages/python/venv.md'
+    #     - Best Practices:   'development/languages/python/best-practices.md'
+    #     - Python on GPU:    'development/languages/python/python-on-gpu.md'
+    #     - Scaling Up:       'development/languages/python/scaling-up.md'
+    #     - Multiprocessing:  'development/languages/python/multiprocessing.md'
+    #     - mpi4py:           'development/languages/python/mpi4py.md'
+    #     - Notebook:         'development/languages/python/notebook.md'
+    #     - Python Profiling: 'development/languages/python/profiling.md'
+    #     - Python FAQ:       'development/languages/python/faq.md'
+    #   - R:    'development/languages/r.md'
+    #   - Ruby: 'development/languages/ruby.md'
+    #   - Rust: 'development/languages/rust.md'
     # - Libraries:
-    #     - About:     'development/libraries/index.md'
-    #     - Boost C++: 'development/libraries/boost.md'
-    #     - FFTW :     'development/libraries/fftw.md'
-    #     - HDF5 :     'development/libraries/hdf5.md'
-    #     - LAPACK :   'development/libraries/lapack.md'
-    #     - MKL :      'development/libraries/mkl.md'
-    #     - NetCDF :   'development/libraries/netcdf.md'
+    #   - About:     'development/libraries/index.md'
+    #   - Boost C++: 'development/libraries/boost.md'
+    #   - FFTW :     'development/libraries/fftw.md'
+    #   - HDF5 :     'development/libraries/hdf5.md'
+    #   - LAPACK :   'development/libraries/lapack.md'
+    #   - MKL :      'development/libraries/mkl.md'
+    #   - NetCDF :   'development/libraries/netcdf.md'
     - Performance/Debugging:
-        # - About:           'development/performance-debugging-tools/index.md'
-        - Arm Forge:       'development/performance-debugging-tools/arm-forge.md'
-        # - GDB:             'development/performance-debugging-tools/gdb.md'
-        - Intel VTune:     'development/performance-debugging-tools/vtune.md'
-        - Intel Advisor:   'development/performance-debugging-tools/advisor.md'
-        - Intel Inspector: 'development/performance-debugging-tools/inspector.md'
-        - Intel Trace Analyzer and Collector: 'development/performance-debugging-tools/itac.md'
-        # - LIKWID:          'development/performance-debugging-tools/likwid.md'
-        # - Nvidia Nsight:   'development/performance-debugging-tools/nsight.md'
-        # - Roofline Performance Model: 'development/performance-debugging-tools/roofline.md'
-        # - PAPI:            'development/performance-debugging-tools/papi.md'
-        - Scalasca:        'development/performance-debugging-tools/scalasca.md'
-        - Valgrind:        'development/performance-debugging-tools/valgrind.md'
-        - APS:             'development/performance-debugging-tools/aps.md'
+      # - About:           'development/performance-debugging-tools/index.md'
+      - Arm Forge:       'development/performance-debugging-tools/arm-forge.md'
+      # - GDB:             'development/performance-debugging-tools/gdb.md'
+      - Intel VTune:     'development/performance-debugging-tools/vtune.md'
+      - Intel Advisor:   'development/performance-debugging-tools/advisor.md'
+      - Intel Inspector: 'development/performance-debugging-tools/inspector.md'
+      - Intel Trace Analyzer and Collector: 'development/performance-debugging-tools/itac.md'
+      # - LIKWID:          'development/performance-debugging-tools/likwid.md'
+      # - Nvidia Nsight:   'development/performance-debugging-tools/nsight.md'
+      # - Roofline Performance Model: 'development/performance-debugging-tools/roofline.md'
+      # - PAPI:            'development/performance-debugging-tools/papi.md'
+      - Scalasca:        'development/performance-debugging-tools/scalasca.md'
+      - Valgrind:        'development/performance-debugging-tools/valgrind.md'
+      - APS:             'development/performance-debugging-tools/aps.md'
   ###############
   # - Applications:
   #   - Overview: 'software/index.md'
@@ -272,8 +272,8 @@ nav:
   #     - ClusterShell: 'tools/clustershell.md'
   #     - GPG: 'tools/gpg.md'
   #     - Git:
-  #         - Basics: 'git/index.md'
-  #         - Workflow: 'git/workflow.md'
+  #       - Basics: 'git/index.md'
+  #       - Workflow: 'git/workflow.md'
   #     - Password Management: 'tools/password-manager.md'
   #   - Configuration Management:
   #     - Puppet: 'infra/management/puppet.md'
@@ -329,7 +329,6 @@ edit_uri: blob/master/docs/
 # Copyright
 copyright: Copyright &copy; 2007-2025 Uni.lu HPC (ULHPC) Team
 
-
 # Configuration
 # strict: true
 
@@ -339,10 +338,10 @@ theme:
   language: en
   palette:
     primary: blue
-    accent:  light blue
+    accent: light blue
   features:
     - navigation.instant
-  # #   - tabs
+    #- navigation.tabs
 
 plugins:
   - search # necessary for search to work

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,11 @@ lunr==0.5.6
 Markdown==3.3.6
 markdown-include==0.8.1
 MarkupSafe==2.0.1
-mkdocs==1.6
+mkdocs==1.6.1
 mkdocs-exclude==1.0.2
 mkdocs-git-revision-date-localized-plugin==1.4.7
 mkdocs-include-markdown-plugin==6.2.2
-mkdocs-material==9.6.14
+mkdocs-material==9.6.16
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.3.0
 nltk==3.5


### PR DESCRIPTION
The upgrade to the newer version of mkdocs breaks the alternate tabs. The fix required upgrading a few environment packages.