### PR TITLE
Bug fixes for GNU parallel

### DIFF
--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -1,18 +1,14 @@
-[GNU parallel](https://www.gnu.org/software/parallel/) allows the execution of multiple small jobs in an HPC cluster without overloading the [cluster scheduler](/slurm/). The Slurm scheduler performs 2 jobs,
+# GNU parallel in HPC systems
+
+Job campaigns that allocate many small jobs quickly, either using job arrays or custom launcher scripts, should use [GNU parallel](https://www.gnu.org/software/parallel/) to reduce the scheduler load. The Slurm scheduler performs 2 jobs,
 
 - allocates resources for a job,
 - launches the [job steps](/jobs/steps/).
 
+Slurm is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180s, depending on its configuration. If many small jobs are in the queue, then operations triggered during the allocation loop, such as backfilling, become expensive. As a result, the scheduling loop can delay past its period, causing the scheduler to appear slow and unresponsive. GNU parallel executes multiple commands in parallel in a single allocation, removing the need to allocate resources and reducing the scheduler load.
 
-<!--
-
-Job steps launch processes within a job which consume the job resources.
-
--->
-
-The Slurm scheduler is designed to allocate resources in an allocation loop that runs periodically, usually every 30-180s, depending on the Slurm configuration. If a lot of small jobs are in the queue, then expensive operations, such as back-filling, are triggered during the allocation loop. As a result, the scheduling loop can delay past its period, causing the scheduler to appear slow and unresponsive.
-
-To avoid multiple small jobs, schedule multiple job steps in a single allocation with GNU parallel.
+!!! info "When should GNU parallel be used?"
+    If you are planning to execute jobs campaigns that require more that 100 job allocations per minute, then please consider using [GNU parallel](https://www.gnu.org/software/parallel/).
 
 ## Running HPC jobs with GNU parallel
 

--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -83,7 +83,7 @@ In these extreme cases, GNU parallel can limit the number of job steps by groupi
     !!! example "Submission script"
         ```bash
         #!/bin/bash --login
-        #SBATCH --job-name=multi_job_per_step_script
+        #SBATCH --job-name=multi_job_step_in_script
         #SBATCH --partition=batch
         #SBATCH --qos=normal
         #SBATCH --nodes=4
@@ -132,7 +132,7 @@ In these extreme cases, GNU parallel can limit the number of job steps by groupi
         parallel \
           --max-procs "${max_parallel_substeps}" \
           --max-args 0 \
-          stress \
+          stress-ng \
             --cpu "${cpus_per_substep}" \
             --timeout "${test_duration}" \
             ::: $(seq 0 "${final_substep}")
@@ -140,9 +140,9 @@ In these extreme cases, GNU parallel can limit the number of job steps by groupi
 
 === "GNU parallel jobs in a function"
     !!! example "Submission script"
-        ```bash
+       ```bash
         #!/bin/bash --login
-        #SBATCH --job-name=multi_job_per_step_function
+        #SBATCH --job-name=multi_job_step_in_function
         #SBATCH --partition=batch
         #SBATCH --qos=normal
         #SBATCH --nodes=4

--- a/docs/jobs/gnu-parallel.md
+++ b/docs/jobs/gnu-parallel.md
@@ -98,9 +98,10 @@ In these extreme cases, GNU parallel can limit the number of job steps by groupi
         declare substeps_per_step=1024
         declare cpus_per_substep=4
 
-        run_job_step() {
+        run_step() {
           local total_substeps="${1}"
           local test_duration="${2}"
+          local cpus_per_substep="${3}"
 
           local final_substep=$(( ${total_substeps} - 1 ))
           local max_parallel_substeps=$(( ${SLURM_CPUS_PER_TASK} / ${cpus_per_substep} ))
@@ -125,7 +126,7 @@ In these extreme cases, GNU parallel can limit the number of job steps by groupi
             --nodes=1 \
             --ntasks=1 \
             bash \
-              -c "\"run_job_step ${substeps_per_step} ${stress_test_duration}\"" \
+              -c "\"run_step ${substeps_per_step} ${stress_test_duration} ${cpus_per_substep}\"" \
               ::: $(seq 0 ${final_step})
         ```
 


### PR DESCRIPTION
Reorganize the presentation to emphasize when GNU parallel is required. A motivating example is required next to tie in the section.