### PR TITLE
[Data Transfer] Expand unmount command for specific Ubuntu case

### DIFF
--- a/docs/data/transfer.md
+++ b/docs/data/transfer.md
@@ -285,27 +285,13 @@ Note the leaving the `[dir]` argument blanck, mounts the user's home directory b
 When you no longer need the mounted remote directory, you **must** unmount your remote file system:
 
 === "Linux"
-	Generic Linux distributions:
     ```bash
     fusermount -u ~/ulhpc 
-    ```
-	Ubuntu (22.04 or newer): 
-	```bash
-    fusermount3 -u ~/ulhpc 
     ```
 === "Mac OS X"
     ```
     diskutil umount ~/ulhpc
     ```
-
-!!! tip
-
-    In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
-
-!!! tip
-
-    In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
-
 !!! tip
 
     In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.

--- a/docs/data/transfer.md
+++ b/docs/data/transfer.md
@@ -306,6 +306,10 @@ When you no longer need the mounted remote directory, you **must** unmount your 
 
     In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
 
+!!! tip
+
+    In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
+
 ## Transfers between long term storage and the HPC facilities
 
 The university provides **central data storage** services for all employees and students. The data are stored securely on the university campus and are **managed by the IT department**. The storage servers most commonly used at the university are

--- a/docs/data/transfer.md
+++ b/docs/data/transfer.md
@@ -302,6 +302,10 @@ When you no longer need the mounted remote directory, you **must** unmount your 
 
     In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
 
+!!! tip
+
+    In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
+
 ## Transfers between long term storage and the HPC facilities
 
 The university provides **central data storage** services for all employees and students. The data are stored securely on the university campus and are **managed by the IT department**. The storage servers most commonly used at the university are

--- a/docs/data/transfer.md
+++ b/docs/data/transfer.md
@@ -285,8 +285,13 @@ Note the leaving the `[dir]` argument blanck, mounts the user's home directory b
 When you no longer need the mounted remote directory, you **must** unmount your remote file system:
 
 === "Linux"
+	Generic Linux distributions:
     ```bash
-    fusermount -u ~/ulhpc
+    fusermount -u ~/ulhpc 
+    ```
+	Ubuntu (22.04 or newer): 
+	```bash
+    fusermount3 -u ~/ulhpc 
     ```
 === "Mac OS X"
     ```

--- a/docs/data/transfer.md
+++ b/docs/data/transfer.md
@@ -298,6 +298,10 @@ When you no longer need the mounted remote directory, you **must** unmount your 
     diskutil umount ~/ulhpc
     ```
 
+!!! tip
+
+    In some APT based systems (e.g. Debian and Ubuntu) the command to unmount the remote directory may be called `fusermount3`.
+
 ## Transfers between long term storage and the HPC facilities
 
 The university provides **central data storage** services for all employees and students. The data are stored securely on the university campus and are **managed by the IT department**. The storage servers most commonly used at the university are


### PR DESCRIPTION
`fusermount`  command does not work for modern Ubuntu releases ([22.04 and newer](https://askubuntu.com/questions/1046816/how-to-umount-non-sudo-sshfs-created-directory)). Instead, users need to use `fusermount3` (i.e. Fuse3)  so we need to add and additional box for Ubuntu users